### PR TITLE
Feature-9: Libraries to Enable Standalone MetaDIG Checks via MetaDIG-py Part 2

### DIFF
--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -159,7 +159,10 @@ def read_csv_with_metadata(d_read, fd, header_line):
         if header_line > 0:
             pd_header_val = header_line - 1
     else:
-        raise TypeError("header_line must be an integer.")
+        raise TypeError(
+            f"header_line must be an integer. Detected type: {type(header_line)}"
+            + f". Value: {header_line}"
+        )
 
     try:
         return pandas.read_csv(io.StringIO(d_read), delimiter=fd, header=pd_header_val), None

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -159,10 +159,15 @@ def read_csv_with_metadata(d_read, fd, header_line):
         if header_line > 0:
             pd_header_val = header_line - 1
     else:
-        raise TypeError(
-            f"header_line must be an integer. Detected type: {type(header_line)}"
-            + f". Value: {header_line}"
+        error_msg = (
+            "Unable to read CSV, cannot determine 'header_line'. It must be an integer."
+            + f" Detected type: {type(header_line)}. Value: {header_line}"
         )
+        return None, error_msg
+        # raise TypeError(
+        #     f"header_line must be an integer. Detected type: {type(header_line)}"
+        #     + f". Value: {header_line}"
+        # )
 
     try:
         return pandas.read_csv(io.StringIO(d_read), delimiter=fd, header=pd_header_val), None

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -115,12 +115,16 @@ def find_entity_index(fname, pid, entity_names, ids):
         z: Index of matching entity in documentation.
         
     """
+    # Checks all elements in entity_names to find matches with fname
     z = [i for i, x in enumerate(entity_names) if x == fname]
+    # If z is empty, we will try to match by pid instead
     if not z:
         z = [i for i, x in enumerate(ids) if x == pid.replace(":", "-")]
 
+    # If there are multiple matches, we will return the first one
     if len(z) > 1:
         z = z[0]
+    # If a single match is found, [0] is the value returned
     return z if z else None
 
 def read_csv_with_metadata(d_read, fd, header_line):

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -113,7 +113,7 @@ def find_entity_index(fname, pid, entity_names, ids):
 
     Returns:
         z: Index of matching entity in documentation.
-        
+
     """
     # Checks all elements in entity_names to find matches with fname
     z = [i for i, x in enumerate(entity_names) if x == fname]
@@ -144,7 +144,7 @@ def read_csv_with_metadata(d_read, fd, header_line):
     # Ensure fd is an int or str
     if isinstance(fd, list):
         fd = fd[0]  # Extract first element if list
-    if not isinstance(fd, (str, int)):  
+    if not isinstance(fd, (str, int)):
         fd = ","  # Default to comma if invalid type
 
     pd_header_val = 0
@@ -168,10 +168,6 @@ def read_csv_with_metadata(d_read, fd, header_line):
             + f" Detected type: {type(header_line)}. Value: {header_line}"
         )
         return None, error_msg
-        # raise TypeError(
-        #     f"header_line must be an integer. Detected type: {type(header_line)}"
-        #     + f". Value: {header_line}"
-        # )
 
     try:
         return pandas.read_csv(io.StringIO(d_read), delimiter=fd, header=pd_header_val), None

--- a/tests/testdata/data.table-text-delimited.glimpse.xml
+++ b/tests/testdata/data.table-text-delimited.glimpse.xml
@@ -56,16 +56,29 @@ def call():
         d_read = obj.read().decode('utf-8', errors = 'replace')
 
         # find which entity file is documented in
-        z = md.find_entity_index(fname, pid, entityNames, ids)
-        if z is None:
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        z = z[0]
+        # Set entity index number to the first item in the list
+        z = index_list[0]
 
+        # Set default value using the entity index
+        num_header_lines = z
+        # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+        if isinstance(headerLines, list):
+            # If we successfully retrieve a list, we will check what the value is
+            if headerLines[z] == 'null':
+                # There are no header lines
+                num_header_lines = 0
+            if isinstance(headerLines[z], int):
+                # We'll use the value from the list of it is an integer
+                num_header_lines = headerLines[z]
+        
         # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], headerLines if isinstance(headerLines, int) else headerLines[z])
+        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
         if error:
             output_data.append(f"{fname} is unable to be read as a table. {error}")
             output_type.append("text")

--- a/tests/testdata/data.table-text-delimited.glimpse.xml
+++ b/tests/testdata/data.table-text-delimited.glimpse.xml
@@ -40,11 +40,11 @@ def call():
         try:
           # if file is not text/csv, skip it
           # otherwise get the object and filename
-          obj, fname, status = md.get_valid_csv(manager, pid)
-          if status == "SKIP":
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
               output_data.append(f"{fname} is not a text-delimited table, skipping.")
               output_type.append("text")
-              status_data.append(status)
+              status_data.append(csv_status)
               continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")

--- a/tests/testdata/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/data.table-text-delimited.normalized.xml
@@ -40,11 +40,11 @@ def call():
         try:
           # if file is not text/csv, skip it
           # otherwise get the object and filename
-          obj, fname, status = md.get_valid_csv(manager, pid)
-          if status == "SKIP":
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
               output_data.append(f"{fname} is not a text-delimited table, skipping.")
               output_type.append("text")
-              status_data.append(status)
+              status_data.append(csv_status)
               continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")

--- a/tests/testdata/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/data.table-text-delimited.normalized.xml
@@ -55,19 +55,36 @@ def call():
         # read in all the data
         d_read = obj.read().decode('utf-8', errors = 'replace')
 
-        # find which entity file is documented in
-        z = md.find_entity_index(fname, pid, entityNames, ids)
-        if z is None:
+       # find which entity file is documented in
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        z = z[0]
+        # Set entity index number to the first item in the list
+        z = index_list[0]
 
+        # Set default value using the entity index
+        num_header_lines = z
+        # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+        if isinstance(headerLines, list):
+            # If we successfully retrieve a list, we will check what the value is
+            if headerLines[z] == 'null':
+                # There are no header lines
+                num_header_lines = 0
+            if isinstance(headerLines[z], int):
+                # We'll use the value from the list of it is an integer
+                num_header_lines = headerLines[z]
+        
         # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], headerLines if isinstance(headerLines, int) else headerLines[z])
+        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
         if error:
-            output_data.append(f"{fname} is unable to be read as a table. {error}")
+            error_msg = (
+              f"{fname} is unable to be read as a table: {error}."
+              + f" Debug Info: entity index z: {z}. headerLines: {headerLines}"
+            )
+            output_data.append(error_msg)
             output_type.append("text")
             status_data.append("FAILURE")
             continue

--- a/tests/testdata/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/data.table-text-delimited.variables-congruent.xml
@@ -40,11 +40,11 @@ def call():
         try:
           # if file is not text/csv, skip it
           # otherwise get the object and filename
-          obj, fname, status = md.get_valid_csv(manager, pid)
-          if status == "SKIP":
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
               output_data.append(f"{fname} is not a text-delimited table, skipping.")
               output_type.append("text")
-              status_data.append(status)
+              status_data.append(csv_status)
               continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")

--- a/tests/testdata/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/data.table-text-delimited.variables-congruent.xml
@@ -66,13 +66,17 @@ def call():
         
         # try to read in the file
         df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], headerLines if isinstance(headerLines, int) else headerLines[z])
-        colnames = list(df.columns)
         if error:
-            output_data.append(f"{fname} is unable to be read as a table.")
+            error_msg = (
+              f"{fname} is unable to be read as a table: {error}."
+              + f"Additional Info: entity index z: {z}. headerLines: {headerLines}"
+            )
+            output_data.append(error_msg)
             output_type.append("text")
             status_data.append("FAILURE")
             continue
 
+        colnames = list(df.columns)
         # extract the entity from the metadata doc and attributeNames
         ent = md.find_eml_entity(document, pid, fname)
         att_names = [elem.text for elem in ent.findall(".//attributeName")]

--- a/tests/testdata/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/data.table-text-delimited.variables-congruent.xml
@@ -56,20 +56,33 @@ def call():
         d_read = obj.read().decode('utf-8', errors = 'replace')
 
         # find which entity file is documented in
-        z = md.find_entity_index(fname, pid, entityNames, ids)
-        if z is None:
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        z = z[0]
+        # Set entity index number to the first item in the list
+        z = index_list[0]
+
+        # Set default value using the entity index
+        num_header_lines = z
+        # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+        if isinstance(headerLines, list):
+            # If we successfully retrieve a list, we will check what the value is
+            if headerLines[z] == 'null':
+                # There are no header lines
+                num_header_lines = 0
+            if isinstance(headerLines[z], int):
+                # We'll use the value from the list of it is an integer
+                num_header_lines = headerLines[z]
         
         # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], headerLines if isinstance(headerLines, int) else headerLines[z])
+        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
         if error:
             error_msg = (
               f"{fname} is unable to be read as a table: {error}."
-              + f"Additional Info: entity index z: {z}. headerLines: {headerLines}"
+              + f" Debug Info: entity index z: {z}. headerLines: {headerLines}"
             )
             output_data.append(error_msg)
             output_type.append("text")

--- a/tests/testdata/data.table-text-delimited.well-formed.xml
+++ b/tests/testdata/data.table-text-delimited.well-formed.xml
@@ -41,11 +41,11 @@ def call():
         try:
           # if file is not text/csv, skip it
           # otherwise get the object and filename
-          obj, fname, status = md.get_valid_csv(manager, pid)
-          if status == "SKIP":
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
               output_data.append(f"{fname} is not a text-delimited table, skipping.")
               output_type.append("text")
-              status_data.append(status)
+              status_data.append(csv_status)
               continue
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")

--- a/tests/testdata/data.table-text-delimited.well-formed.xml
+++ b/tests/testdata/data.table-text-delimited.well-formed.xml
@@ -57,22 +57,38 @@ def call():
         d_read = obj.read(1024).decode('utf-8', errors = 'replace')
         
         # find which entity file is documented in
-        z = md.find_entity_index(fname, pid, entityNames, ids)
-        if z is None:
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        z = z[0]
+        # Set entity index number to the first item in the list
+        z = index_list[0]
         
         # try to read it in as a csv with correct metadata
         try:
-            df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], headerLines if isinstance(headerLines, int) else headerLines[z])
+            # Set default value using the entity index
+            num_header_lines = z
+
+            # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+            if isinstance(headerLines, list):
+                # If we successfully retrieve a list, we will check what the value is
+                if headerLines[z] == 'null':
+                    # There are no header lines
+                    num_header_lines = 0
+                if isinstance(headerLines[z], int):
+                    # We'll use the value from the list of it is an integer
+                    num_header_lines = headerLines[z]
+            
+            # try to read in the file
+            df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
         except Exception as e:
             output_data.append(f"{fname} is unable to be read as a table.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
+            
         if isinstance(df, pd.DataFrame):
             output_data.append(f"{fname} is able to be parsed.")
             output_type.append("text")


### PR DESCRIPTION
**Summary of Changes:**
- Refactored `read_csv_with_metadata` to return values instead of raising an exception when a `header_line` integer is not found
- Added code comments to improve clarity for `find_entity_index` function in `metadata` module
- Update pytest `testdata/` data checks to their latest versions