### PR TITLE
Feature-32: `conftest.py` Refactor Part 2

### DIFF
--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -69,8 +69,38 @@ def test_run_check_datatable_variables_congruent(storemanager_props, init_hashst
     assert result_data is not None
     assert result_data["identifiers"] is not None
     assert result_data["output"] is not None
-    assert "variable names match documentation." in result_data["output"][0]
+    assert "variable names do not match documentation." in result_data["output"][0]
     assert result_data["status"] is not None
+
+
+def test_run_check_datatable_normalized(storemanager_props, init_hashstore_with_test_data):
+    """Test 'run_check' with 'data.table-text-delimited.normalized.xml' python check."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+    # Confirm no exception is thrown and object and metadata is in place
+    _ = manager.get_object("urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1")
+
+    # Now execute 'run_check' by providing it the required args
+    sample_check_file_path = get_test_data_path(
+        "checks/data.table-text-delimited.normalized.xml"
+    )
+    sample_metadata_file_path = get_test_data_path("doi:10.18739_A2QJ78081.xml")
+    sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
+
+    result = checks.run_check(
+        sample_check_file_path,
+        sample_metadata_file_path,
+        sample_sysmeta_file_path,
+        storemanager_props,
+    )
+
+    result_data = json.loads(result)
+    # print(result_data)
+    assert result_data is not None
+    assert result_data["identifiers"] is not None
+    assert result_data["output"] is not None
+    assert "contains normalization issues" in result_data["output"][0]
+    assert result_data["status"] == "FAILURE"
 
 
 def test_try_run_check_with_multiprocessing(storemanager_props, init_hashstore_with_test_data):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -176,8 +176,7 @@ def test_find_duplicate_column_content_none(storemanager_props, init_hashstore_w
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -213,8 +212,7 @@ def test_find_duplicate_column_names_none(storemanager_props, init_hashstore_wit
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -250,7 +248,7 @@ def test_find_duplicate_rows_none(storemanager_props, init_hashstore_with_test_d
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -285,7 +283,7 @@ def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_dat
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -294,4 +292,4 @@ def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_dat
 
     df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
     num_of_cols = metadata.find_number_of_columns(df)
-    assert num_of_cols == 33
+    assert num_of_cols == 9

--- a/tests/testdata/checks/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/checks/data.table-text-delimited.normalized.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdq:check xmlns:mdq="https://nceas.ucsb.edu/mdqe/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://nceas.ucsb.edu/mdqe/v1 ../schemas/schema1.xsd">
+  <id>data.table-text-delimited.normalized</id>
+  <name>Check whether the data is normalized.</name>
+  <description>Data is normalized when there are no duplicate columns or rows and does not contain duplicate column or row names </description>
+  <type>identification</type>
+  <level>INFO</level>
+  <environment>python</environment>
+  <code><![CDATA[
+
+def call():
+    global output
+    global status
+    global output_identifiers
+    global output_type
+    global metadigpy_result
+
+    from metadig import StoreManager
+    from metadig import metadata
+    import metadig as md
+    import pandas as pd
+    import io
+
+    manager = StoreManager(storeConfiguration)  
+
+    output_data = []
+    status_data = []
+    output_identifiers = []
+    output_type = []
+    metadigpy_result = {}
+
+    if len(dataPids) == 0:
+      output_data = "No data objects found."
+
+    for pid in dataPids:
+        output_identifiers.append(pid)
+
+        # If data object is not available, skip the pid.
+        try:
+          # if file is not text/csv, skip it
+          # otherwise get the object and filename
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
+              output_data.append(f"{fname} is not a text-delimited table, skipping.")
+              output_type.append("text")
+              status_data.append(csv_status)
+              continue
+        except Exception as e:
+            output_data.append(f"Unexpected Exception: {e}")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+
+        # read in all the data
+        d_read = obj.read().decode('utf-8', errors = 'replace')
+
+        # find which entity file is documented in
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
+            output_data.append(f"{fname} does not appear to be documented in the metadata.")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+        # Set entity index number to the first item in the list
+        z = index_list[0]
+
+        # Set default value using the entity index
+        num_header_lines = z
+        # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+        if isinstance(headerLines, list):
+            # If we successfully retrieve a list, we will check what the value is
+            if headerLines[z] == 'null':
+                # There are no header lines
+                num_header_lines = 0
+            if isinstance(headerLines[z], int):
+                # We'll use the value from the list of it is an integer
+                num_header_lines = headerLines[z]
+        
+        # try to read in the file
+        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
+        if error:
+            output_data.append(f"{fname} is unable to be read as a table. {error}")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+
+        # If any errors are found, the data will not pass the normalized check
+        normalization_errors_count = 0
+        normalization_errors_data = []
+
+        # Check for duplicate field names
+        duplicate_cols, contains_period = metadata.find_duplicate_column_names(df)
+        if duplicate_cols:
+            normalization_errors_count += 1
+            normalization_errors_data.append(f"{fname} contains duplicate columns: {', '.join(duplicate_cols)}")
+        elif contains_period:
+            # Add a warning if there's no duplicates and a period is found in the field
+            warn_msg = f"{fname} has periods '.' in the field names. We recommend replacing with underscores '_'"
+            normalization_errors_data.append(warn_msg)
+
+        # Check for duplicate column content
+        duplicate_col_content = metadata.find_duplicate_column_content(df)
+        if len(duplicate_col_content) != 0:
+            normalization_errors_count += 1
+            error_msg = "; ".join(
+                f"'{dup}' duplicates '{orig}' (hash: {h})"
+                for dup, orig, h in duplicate_col_content
+            )
+            normalization_errors_data.append(
+                f"{fname} contains duplicate column content: {error_msg}"
+            )
+
+        # Check for duplicate rows
+        duplicate_rows = metadata.find_duplicate_rows(df)
+        if duplicate_rows is not None:
+            dr_summary = duplicate_rows.to_markdown()
+            normalization_errors_count += 1
+            normalization_errors_data.append(
+                f"{fname} contains duplicate rows: \n{dr_summary} \n"
+            )
+
+        # Check for obscene amount of columns
+        num_of_cols = metadata.find_number_of_columns(df)
+        if num_of_cols >= 1000:
+            normalization_errors_count += 1
+            normalization_errors_data.append(
+                f"{fname} contains an excessive number of columns: {num_of_cols}"
+            )
+
+        # TODO: DISCUSS - Adding check for reasonable amount of non-repeating values
+
+        norm_errors_md_output = '\n'.join(f'| {line}' for line in normalization_errors_data)
+        if normalization_errors_count == 0:
+            if normalization_errors_data:
+                output_data.append(f"{fname} is normalized. Additional Details: {norm_errors_md_output}")
+            else:
+                output_data.append(f"{fname} is normalized.")
+            output_type.append("markdown")
+            status_data.append("SUCCESS")
+        else:
+            output_data.append(f"{fname} contains normalization issues: {norm_errors_md_output}")
+            output_type.append("markdown")
+            status_data.append("FAILURE")
+
+    successes = sum(x == "SUCCESS" for x in status_data)
+    failures = sum(x == "FAILURE" for x in status_data)
+    skips = sum(x == "SKIP" for x in status_data)
+    output = output_data
+    if successes > 0 and failures == 0:
+        status = "SUCCESS"
+    elif successes == 0 and failures > 0:
+        status = "FAILURE"
+    else:
+        status = "FAILURE" 
+
+    metadigpy_result["identifiers"] = output_identifiers
+    metadigpy_result["output"] = output_data
+    metadigpy_result["status"] = status
+    return True
+
+  ]]></code>
+  <selector>
+    <name>entityNames</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+    <subSelector>
+      <name>...</name>
+      <xpath>./entityName</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+    <name>objectNames</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+    <subSelector>
+      <name>...</name>
+      <xpath>./physical/objectName</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+    <name>ids</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]/@id</xpath>
+  </selector>
+  <selector>
+     <name>fieldDelimiter</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+     <subSelector>
+        <name>...</name>
+        <xpath>./physical/dataFormat/textFormat/simpleDelimited/fieldDelimiter</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+     <name>headerLines</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+     <subSelector>
+        <name>...</name>
+        <xpath>./physical/dataFormat/textFormat/numHeaderLines</xpath>
+    </subSelector>
+  </selector>
+  <dialect>
+    <name>Ecological Metadata Language</name>
+    <xpath>boolean(/*[local-name() = 'eml'])</xpath>
+  </dialect>
+</mdq:check>


### PR DESCRIPTION
**Summary of Changes:**
- Modified existing pytests for the `test_metadata` module to use test data not associated with a dataset
- Added new pytest to `test_checks` module to run the initial `data.table-text-delimited.normalized.xml` and altered existing test data document to create normalization issues, and added the actual check to `tests/testdata/checks`