### PR TITLE
Feature-36: Improve Check Testing Process & Module Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ ENV/
 # Rope project settings
 .ropeproject
 .vscode/settings.json
+
+# HashStore settings
+# Allow hashstore/ and its immediate subfolders
+hashstore/*

--- a/hashstore/hashstore.yaml
+++ b/hashstore/hashstore.yaml
@@ -1,0 +1,45 @@
+
+# Default configuration variables for HashStore
+
+############### HashStore Config Notes ###############
+############### Directory Structure ###############
+# store_depth
+# - Desired amount of directories when sharding an object to form the permanent address
+# - **WARNING**: DO NOT CHANGE UNLESS SETTING UP NEW HASHSTORE
+#
+# store_width
+# - Width of directories created when sharding an object to form the permanent address
+# - **WARNING**: DO NOT CHANGE UNLESS SETTING UP NEW HASHSTORE
+#
+# Example:
+# Below, objects are shown listed in directories that are 3 levels deep (DIR_DEPTH=3),
+# with each directory consisting of 2 characters (DIR_WIDTH=2).
+#    /var/filehashstore/objects
+#    ├── 7f
+#    │   └── 5c
+#    │       └── c1
+#    │           └── 8f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6
+
+############### Format of the Metadata ###############
+# store_metadata_namespace
+# - The default metadata format (ex. system metadata)
+
+############### Hash Algorithms ###############
+# store_algorithm
+# - Hash algorithm to use when calculating object's hex digest for the permanent address
+#
+# store_default_algo_list
+# - Algorithm values supported by python hashlib 3.9.0+ for File Hash Store (FHS)
+# - The default algorithm list includes the hash algorithms calculated when storing an
+# - object to disk and returned to the caller after successful storage.
+
+store_depth: 3
+store_width: 2
+store_metadata_namespace: https://ns.dataone.org/service/types/v2.0#SystemMetadata
+store_algorithm: SHA-256
+store_default_algo_list:
+- MD5
+- SHA-1
+- SHA-256
+- SHA-384
+- SHA-512

--- a/metadig/__init__.py
+++ b/metadig/__init__.py
@@ -22,6 +22,7 @@ from .metadata import find_eml_entity
 from .metadata import find_entity_index
 from .metadata import read_csv_with_metadata
 from .metadata import get_valid_csv
+from .metadigclient import MetaDigClientUtilities
 
 __all__ = [
     "StoreManager",
@@ -38,4 +39,5 @@ __all__ = [
     "checks",
     "metadata",
     "suites",
+    "MetaDigClientUtilities",
 ]

--- a/metadig/__init__.py
+++ b/metadig/__init__.py
@@ -22,6 +22,7 @@ from .metadata import find_eml_entity
 from .metadata import find_entity_index
 from .metadata import read_csv_with_metadata
 from .metadata import get_valid_csv
+from .metadata import detect_text_encoding
 from .metadigclient import MetaDigClientUtilities
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "find_entity_index",
     "read_csv_with_metadata",
     "get_valid_csv",
+    "detect_text_encoding",
     "run_check",
     "checks",
     "metadata",

--- a/metadig/checks.py
+++ b/metadig/checks.py
@@ -115,10 +115,7 @@ def get_data_pids(identifier: str, member_node: str):
         # Send the request and read the response
         with urllib.request.urlopen(req) as response:
             # Read and decode the response
-            data = response.read().decode("utf-8")
-            # Convert the string to bytes so lxml can parse it
-            xml_bytes = data.encode("utf-8")
-            # Iterate over the response to get all the data pids
+            xml_bytes = response.read()
             # pylint: disable=I1101
             root = etree.fromstring(xml_bytes)
 

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -4,7 +4,6 @@ import xml.etree.ElementTree as ET
 import io
 import hashlib
 import pandas
-import checks
 
 
 def read_sysmeta_element(stream, element):

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -286,3 +286,26 @@ def detect_text_encoding(raw: bytes):
         err_msg = (
             f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
         return 'other', err_msg
+
+
+# TODO: Determine where this function should exist
+
+def import_data_to_hashstore(metadata_sysmeta_path: str, path_to_data_folder: str):
+    """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
+    then parses the given path to the data folder to store the data objects into the metadig-py
+    hashstore. The system metadata for each data object is also retrieved and stored.
+
+    :param str metadata_sysmeta_path: Path to the sysmeta for the XML metadata document.
+    :param str path_to_data_folder: Path to the folder containing data objects to store.
+    :return: The result of the suite function.
+    """
+    # Read the sysmeta
+    # Get the identifier and mn node
+    # Get the data pids
+    # For each data pid
+    ## Get the system metadata
+    ## Read and parse it for the file name
+    ## Find the file name in the given folder
+    ## Store the data object
+    ## Store the data object for the system metadata
+    return

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -129,12 +129,13 @@ def find_entity_index(fname, pid, entity_names, ids):
     # If a single match is found, [0] is the value returned
     return z if z else None
 
-def read_csv_with_metadata(d_read, fd, header_line):
+def read_csv_with_metadata(d_read, fd, header_line, d_encoding=None):
     """Uses pandas to read in a csv with given field delimiter and header rows to skip
 
     :param str or bytes d_read: RData as read in from the stream
     :param str fd: ield delimiter from metadata
     :param int header_line: Number of rows to skip
+    :param str d_encoding: Encoding type to use to read the given bytes
 
     :return: A tuple containing:
         - df: Pandas data.frame with data
@@ -169,7 +170,23 @@ def read_csv_with_metadata(d_read, fd, header_line):
         return None, error_msg
 
     try:
-        return pandas.read_csv(io.StringIO(d_read), delimiter=fd, header=pd_header_val), None
+        if d_encoding is not None:
+            return (
+                pandas.read_csv(
+                    io.StringIO(d_read),
+                    delimiter=fd,
+                    header=pd_header_val,
+                    encoding=d_encoding,
+                ),
+                None,
+            )
+        else:
+            return (
+                pandas.read_csv(
+                    io.StringIO(d_read), delimiter=fd, header=pd_header_val
+                ),
+                None,
+            )
     # pylint: disable=W0718
     except Exception as e:
         return None, f"Error reading CSV: {str(e)}"

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 import io
 import hashlib
 import pandas
+import checks
 
 
 def read_sysmeta_element(stream, element):
@@ -286,26 +287,3 @@ def detect_text_encoding(raw: bytes):
         err_msg = (
             f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
         return 'other', err_msg
-
-
-# TODO: Determine where this function should exist
-
-def import_data_to_hashstore(metadata_sysmeta_path: str, path_to_data_folder: str):
-    """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
-    then parses the given path to the data folder to store the data objects into the metadig-py
-    hashstore. The system metadata for each data object is also retrieved and stored.
-
-    :param str metadata_sysmeta_path: Path to the sysmeta for the XML metadata document.
-    :param str path_to_data_folder: Path to the folder containing data objects to store.
-    :return: The result of the suite function.
-    """
-    # Read the sysmeta
-    # Get the identifier and mn node
-    # Get the data pids
-    # For each data pid
-    ## Get the system metadata
-    ## Read and parse it for the file name
-    ## Find the file name in the given folder
-    ## Store the data object
-    ## Store the data object for the system metadata
-    return

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 import io
 import hashlib
 import pandas
+import chardet
 
 
 def read_sysmeta_element(stream, element):
@@ -283,6 +284,10 @@ def detect_text_encoding(raw: bytes):
         raw.decode("utf-8")
         return "utf-8", None
     except UnicodeDecodeError as e:
+        # If we attempt to decode as utf-8 and run into exceptions, it may contain other
+        # illegal characters. We will attempt to detect the encoding and return the error message.
         err_msg = (
             f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
-        return 'other', err_msg
+        detected_encoding_result = chardet.detect(raw)
+        encoding = detected_encoding_result.get('encoding')
+        return encoding, err_msg

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -163,13 +163,15 @@ class MetaDigClientUtilities:
         else:
             # Store the data object and system metadata
             for pid in data_pids:
+                # TODO: This should be done in a try-except block so that we attempt
+                #       every data pid found.
                 data_obj_name, sysmeta = self.get_data_object_system_metadata(
                     identifier, auth_mn_node
                 )
                 ## TODO: Find the file name in the given folder
                 ## TODO: Store the data object
-                ## TODO: Store the data object for the system metadata
-                self.default_store.store_metadata(pid, sysmeta)
+                ## TODO: Store the system metadata for the data object
+                # self.default_store.store_metadata(pid, sysmeta)
             return
 
 def main():

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -74,8 +74,14 @@ class MetaDigClientUtilities:
         :return: The result of the suite function.
         """
         # Read the sysmeta
-        # Get the identifier and mn node
-        # Get the data pids
+        sysmeta_vars = checks.get_sysmeta_vars(metadata_sysmeta_path)
+        identifier = sysmeta_vars.get("identifier")
+        auth_mn_node = sysmeta_vars.get("authoritative_member_node")
+        data_pids = checks.get_data_pids(identifier, auth_mn_node)
+
+        # Store the data object and system metadata
+        for pid in data_pids:
+            print(pid)
         # For each data pid
         ## Get the system metadata
         ## Read and parse it for the file name

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -85,6 +85,7 @@ class MetaDigClientUtilities:
         
         :param str path_to_data_folder: Path to the folder containing data objects to store.
         :return: Dictionary containing store manager properties
+        :rtype: Dict
         """
         hashstore_yaml_path = store_path + "/hashstore.yaml"
         if not os.path.isfile(hashstore_yaml_path):
@@ -147,7 +148,14 @@ class MetaDigClientUtilities:
 
     @staticmethod
     def find_file(folder_to_check: str, file_to_find: str):
-        """Check the supplied folder for the given file and return its full path"""
+        """Check the supplied folder for the given file and return its full path. This function
+        will also search subfolders.
+        
+        :param str folder_to_check: Folder that contains data files
+        :param str file_to_find: The data file to look for
+        :return: Path to the data object
+        :rtype: Path
+        """
         folder_path = Path(folder_to_check)
         for path in folder_path.rglob(file_to_find):
             return path
@@ -182,9 +190,9 @@ class MetaDigClientUtilities:
                 )
                 ## Find the file name in the given folder
                 data_object_path = self.find_file(path_to_data_folder, data_obj_name)
-                # if data_object_path is not None:
-                #     self.default_store.store_object(pid, data_object_path)
-                #     self.default_store.store_metadata(pid, sysmeta)
+                if data_object_path is not None:
+                    self.default_store.store_object(pid, data_object_path)
+                    self.default_store.store_metadata(pid, sysmeta)
             return
 
 def main():

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -66,6 +66,8 @@ class MetaDigPyParser:
 class MetaDigClientUtilities:
     """Class to assist the metadig client with running checks and/or suites."""
 
+    # TODO: Initialize default metadig-py hashstore
+
     @staticmethod
     def get_data_object_system_metadata(identifier: str, member_node: str):
         """Retrieve the system metadata for a data object with the given identifier and
@@ -123,13 +125,12 @@ class MetaDigClientUtilities:
 
         # Store the data object and system metadata
         for pid in data_pids:
-            print(pid)
-        # For each data pid
-        ## Get the system metadata
-        ## Read and parse it for the file name
-        ## Find the file name in the given folder
-        ## Store the data object
-        ## Store the data object for the system metadata
+            data_obj_name, sysmeta = self.get_data_object_system_metadata(
+                identifier, auth_mn_node
+            )
+            ## TODO: Find the file name in the given folder
+            ## TODO: Store the data object
+            ## TODO: Store the data object for the system metadata
         return
 
 def main():

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -60,6 +60,30 @@ class MetaDigPyParser:
         """Get command line arguments."""
         return self.parser.parse_args()
 
+
+class MetaDigClientUtilities:
+    """Class to assist the metadig client with running checks and/or suites."""
+
+    def import_data_to_hashstore(self, metadata_sysmeta_path: str, path_to_data_folder: str):
+        """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
+        then parses the given path to the data folder to store the data objects into the metadig-py
+        hashstore. The system metadata for each data object is also retrieved and stored.
+
+        :param str metadata_sysmeta_path: Path to the sysmeta for the XML metadata document.
+        :param str path_to_data_folder: Path to the folder containing data objects to store.
+        :return: The result of the suite function.
+        """
+        # Read the sysmeta
+        # Get the identifier and mn node
+        # Get the data pids
+        # For each data pid
+        ## Get the system metadata
+        ## Read and parse it for the file name
+        ## Find the file name in the given folder
+        ## Store the data object
+        ## Store the data object for the system metadata
+        return
+
 def main():
     """Entry point of the Metadig client."""
     # Set-up parser and retrieve arguments

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -35,6 +35,12 @@ class MetaDigPyParser:
             action="store_true",
             help="Flag to run a check through the MetaDIG-py client",
         )
+        self.parser.add_argument(
+            "-importhashstoredata",
+            dest="import_hashstore_data",
+            action="store_true",
+            help="Flag to run import data to a hashstore using the MetaDIG-py client",
+        )
 
         # Arguments to retrieve to run a check
         self.parser.add_argument(
@@ -59,7 +65,13 @@ class MetaDigPyParser:
             "-sysmeta",
             "-sysmeta_doc",
             dest="sysmeta_path",
-            help="Path to document to the sysmeta to retrieve the identifier and member node",
+            help="Path to document to the sysmeta to retrieve the identifier and member node.",
+        )
+        self.parser.add_argument(
+            "-datafolder",
+            "-data_folder",
+            dest="data_folder_path",
+            help="Path to folder containining the desired data objects to upload to hashstore.",
         )
 
     def get_parser_args(self):
@@ -246,15 +258,17 @@ def main():
     check_xml_path = getattr(args, "checkxml_path")
     metadata_doc_path = getattr(args, "metadatadoc_path")
     sysmeta_path = getattr(args, "sysmeta_path")
+    import_hashstore_data = getattr(args, "import_hashstore_data")
+    data_folder_path = getattr(args, "data_folder_path")
     if run_check:
         if store_path is None:
-            raise ValueError("'-store_path' arg is required")
+            raise ValueError("'-store_path' arg is required to run a check")
         if check_xml_path is None:
-            raise ValueError("'-check_xml' arg is required")
+            raise ValueError("'-check_xml' arg is required to run a check")
         if metadata_doc_path is None:
-            raise ValueError("'-metadata_doc' arg is required")
+            raise ValueError("'-metadata_doc' arg is required to run a check")
         if sysmeta_path is None:
-            raise ValueError("'-sysmeta_doc' arg is required")
+            raise ValueError("'-sysmeta_doc' arg is required to run a check")
 
         # Get the store configuration from the given config file at the store_path
         storemanager_props = mcdu.get_store_manager_props(store_path)
@@ -264,6 +278,13 @@ def main():
             check_xml_path, metadata_doc_path, sysmeta_path, storemanager_props
         )
         print(result)
+        return
+    if import_hashstore_data:
+        if data_folder_path is None:
+            raise ValueError("'-data_folder' arg is required to import hashstore data")
+        if sysmeta_path is None:
+            raise ValueError("'-sysmeta_doc' arg is required to import hashstore data")
+        # TODO: Import data
         return
 
 if __name__ == "__main__":

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -85,12 +85,12 @@ class MetaDigClientUtilities:
     def __init__(self):
         """Initialize the default properties for the MetaDigClientUtilities (ex. hashstore)"""
         default_hashstore_path = os.getcwd() + "/hashstore"
-        storemanager_props = self.get_store_manager_props(default_hashstore_path)
+        self.default_store_props = self.get_store_manager_props(default_hashstore_path)
         hashstore_factory = HashStoreFactory()
         module_name = "hashstore.filehashstore"
         class_name = "FileHashStore"
         self.default_store = hashstore_factory.get_hashstore(
-            module_name, class_name, storemanager_props
+            module_name, class_name, self.default_store_props
         )
 
     @staticmethod

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -66,8 +66,8 @@ class MetaDigPyParser:
 class MetaDigClientUtilities:
     """Class to assist the metadig client with running checks and/or suites."""
 
-    # TODO: Static member?
-    def get_data_object_system_metadata(self, identifier: str, member_node: str):
+    @staticmethod
+    def get_data_object_system_metadata(identifier: str, member_node: str):
         """Retrieve the system metadata for a data object with the given identifier and
         member node endpoint
 

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -198,7 +198,6 @@ class MetaDigClientUtilities:
                 data_object_path = self.find_file(path_to_data_folder, data_obj_name)
                 if data_object_path is not None:
                     if hashstore_path is None:
-                        print("Storing object and metadata")
                         try:
                             self.default_store.store_object(pid, data_object_path)
                         except HashStoreRefsAlreadyExists as hsrae:

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -82,7 +82,7 @@ class MetaDigClientUtilities:
         )
 
     @staticmethod
-    def get_store_manager_props(store_path):
+    def get_store_manager_props(store_path) -> dict:
         """Given a path, look for the 'hashstore.yaml' configuration file and return a dictionary
         that contains the properties found in the config file.
         
@@ -109,7 +109,7 @@ class MetaDigClientUtilities:
         return storemanager_props
 
     @staticmethod
-    def get_data_object_system_metadata(identifier: str, member_node: str):
+    def get_data_object_system_metadata(identifier: str, member_node: str) -> tuple:
         """Retrieve the system metadata for a data object with the given identifier and
         member node endpoint
 
@@ -149,7 +149,7 @@ class MetaDigClientUtilities:
         return data_obj_file_name, system_metadata
 
     @staticmethod
-    def find_file(folder_to_check: str, file_to_find: str):
+    def find_file(folder_to_check: str, file_to_find: str) -> Path:
         """Check the supplied folder for the given file and return its full path. This function
         will also search subfolders.
 
@@ -169,7 +169,7 @@ class MetaDigClientUtilities:
         metadata_sysmeta_path: str,
         path_to_data_folder: str,
         hashstore_path: Optional[str] = None,
-    ):
+    ) -> list:
         """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
         then parses the given path to the data folder to store the data objects into the metadig-py
         hashstore. The system metadata for each data object is also retrieved and stored.

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -284,7 +284,14 @@ def main():
             raise ValueError("'-data_folder' arg is required to import hashstore data")
         if sysmeta_path is None:
             raise ValueError("'-sysmeta_doc' arg is required to import hashstore data")
-        # TODO: Import data
+        # If 'store_path' is None, we will use the default hashstore that ships with metadig-py
+
+        # Parse the sysmeta for the data pids, retrieve the system metadata and store
+        # both the data objects and their respective sysmeta to hashstore
+        data_pids_stored = mcdu.import_data_to_hashstore(
+            sysmeta_path, data_folder_path, store_path
+        )
+        print(f"Data objects have been stored for pids: {data_pids_stored}")
         return
 
 if __name__ == "__main__":

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -4,9 +4,9 @@ import os
 from argparse import ArgumentParser
 import urllib.parse
 import yaml
-from metadig import checks
 from lxml import etree
-
+from hashstore import HashStoreFactory
+from metadig import checks
 
 class MetaDigPyParser:
     """Class to set up parsing arguments via argparse."""
@@ -66,7 +66,16 @@ class MetaDigPyParser:
 class MetaDigClientUtilities:
     """Class to assist the metadig client with running checks and/or suites."""
 
-    # TODO: Initialize default metadig-py hashstore
+    def __init__(self):
+        """Initialize the default properties for the MetaDigClientUtilities (ex. hashstore)"""
+        default_hashstore_path = os.getcwd() + "/hashstore"
+        storemanager_props = self.get_store_manager_props(default_hashstore_path)
+        hashstore_factory = HashStoreFactory()
+        module_name = "hashstore.filehashstore"
+        class_name = "FileHashStore"
+        self.default_store = hashstore_factory.get_hashstore(
+            module_name, class_name, storemanager_props
+        )
 
     @staticmethod
     def get_store_manager_props(store_path):
@@ -149,15 +158,22 @@ class MetaDigClientUtilities:
         auth_mn_node = sysmeta_vars.get("authoritative_member_node")
         data_pids = checks.get_data_pids(identifier, auth_mn_node)
 
-        # Store the data object and system metadata
-        for pid in data_pids:
-            data_obj_name, sysmeta = self.get_data_object_system_metadata(
-                identifier, auth_mn_node
-            )
-            ## TODO: Find the file name in the given folder
-            ## TODO: Store the data object
-            ## TODO: Store the data object for the system metadata
-        return
+        if len(data_pids) == 0:
+            raise ValueError(f"No data pids found for identifier: {identifier}")
+        else:
+            # Initialize the default hashstore
+            mcdu = MetaDigClientUtilities()
+
+            # Store the data object and system metadata
+            for pid in data_pids:
+                data_obj_name, sysmeta = self.get_data_object_system_metadata(
+                    identifier, auth_mn_node
+                )
+                ## TODO: Find the file name in the given folder
+                ## TODO: Store the data object
+                ## TODO: Store the data object for the system metadata
+                # mcdu.default_store.store_metadata(pid, sysmeta)
+            return
 
 def main():
     """Entry point of the Metadig client."""

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Metadig Command Line App"""
 import os
+from pathlib import Path
 from argparse import ArgumentParser
 import urllib.parse
 import yaml
@@ -143,6 +144,17 @@ class MetaDigClientUtilities:
 
         return data_obj_file_name, system_metadata
 
+
+    @staticmethod
+    def find_file(folder_to_check: str, file_to_find: str):
+        """Check the supplied folder for the given file and return its full path"""
+        folder_path = Path(folder_to_check)
+        for path in folder_path.rglob(file_to_find):
+            return path
+        # If nothing is found
+        return None
+
+
     def import_data_to_hashstore(self, metadata_sysmeta_path: str, path_to_data_folder: str):
         """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
         then parses the given path to the data folder to store the data objects into the metadig-py
@@ -168,10 +180,11 @@ class MetaDigClientUtilities:
                 data_obj_name, sysmeta = self.get_data_object_system_metadata(
                     identifier, auth_mn_node
                 )
-                ## TODO: Find the file name in the given folder
-                ## TODO: Store the data object
-                ## TODO: Store the system metadata for the data object
-                # self.default_store.store_metadata(pid, sysmeta)
+                ## Find the file name in the given folder
+                data_object_path = self.find_file(path_to_data_folder, data_obj_name)
+                # if data_object_path is not None:
+                #     self.default_store.store_object(pid, data_object_path)
+                #     self.default_store.store_metadata(pid, sysmeta)
             return
 
 def main():

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -161,9 +161,6 @@ class MetaDigClientUtilities:
         if len(data_pids) == 0:
             raise ValueError(f"No data pids found for identifier: {identifier}")
         else:
-            # Initialize the default hashstore
-            mcdu = MetaDigClientUtilities()
-
             # Store the data object and system metadata
             for pid in data_pids:
                 data_obj_name, sysmeta = self.get_data_object_system_metadata(
@@ -172,12 +169,13 @@ class MetaDigClientUtilities:
                 ## TODO: Find the file name in the given folder
                 ## TODO: Store the data object
                 ## TODO: Store the data object for the system metadata
-                # mcdu.default_store.store_metadata(pid, sysmeta)
+                self.default_store.store_metadata(pid, sysmeta)
             return
 
 def main():
     """Entry point of the Metadig client."""
     # Set-up parser and retrieve arguments
+    mcdu = MetaDigClientUtilities()
     parser = MetaDigPyParser()
     args = parser.get_parser_args()
 
@@ -197,7 +195,7 @@ def main():
             raise ValueError("'-sysmeta_doc' arg is required")
 
         # Get the store configuration from the given config file at the store_path
-        storemanager_props = MetaDigClientUtilities.get_store_manager_props(store_path)
+        storemanager_props = mcdu.get_store_manager_props(store_path)
 
         # Run the check
         result = checks.run_check(

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -66,6 +66,7 @@ class MetaDigPyParser:
 class MetaDigClientUtilities:
     """Class to assist the metadig client with running checks and/or suites."""
 
+    # TODO: Static member?
     def get_data_object_system_metadata(self, identifier: str, member_node: str):
         """Retrieve the system metadata for a data object with the given identifier and
         member node endpoint
@@ -74,7 +75,6 @@ class MetaDigClientUtilities:
         :param str member_node: The member node whose URL to query (ex. 'urn:node:ARCTIC')
         :return: 
         """
-        # TODO
         member_node_url = checks.get_member_node_url(member_node)
         encoded_identifier = urllib.parse.quote(identifier)
         sysmeta_query = f"/meta/{encoded_identifier}"
@@ -87,9 +87,8 @@ class MetaDigClientUtilities:
             # Send the request and read the response
             with urllib.request.urlopen(req) as response:
                 # Read and decode the response
-                data = response.read().decode("utf-8")
+                xml_bytes = response.read()
                 # Convert the string to bytes so lxml can parse it
-                xml_bytes = data.encode("utf-8")
                 print(xml_bytes)
                 # Iterate over the response to get all the data pids
                 # pylint: disable=I1101
@@ -99,8 +98,13 @@ class MetaDigClientUtilities:
             raise RuntimeError(f"Unexpected exception encountered: {ge}") from ge
         
         # TODO: Return the sysmeta bytes, or save it to a tmp file?
+        data_obj_file_name = None
+        for elem in root.iter():
+            if elem.tag.endswith("fileName"):
+                data_obj_file_name = elem.text
+                break
 
-        return
+        return data_obj_file_name
 
     def import_data_to_hashstore(self, metadata_sysmeta_path: str, path_to_data_folder: str):
         """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,10 @@ def init_hashstore_with_test_data(store):
     # Store associated data objects and sysmeta
     store.store_object(
         "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",
-        os.path.join(testdata_dir, "the_arctic_plant_aboveground_biomass_synthesis_dataset.csv")
+        os.path.join(
+            testdata_dir,
+            "the_arctic_plant_aboveground_biomass_synthesis_dataset_v1_2.csv",
+        ),
     )
     store.store_metadata(
         "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def init_hashstore_with_test_data(store):
         ("test-pid-4dupcols", "test-data_duplicate_columns.csv"),
         ("test-pid-dupcols-names", "test-data_duplicate_columns_dif_names.csv"),
         ("test-pid-duprows", "test-data_duplicate_rows.csv"),
-        ("test-pid-decode-errors", "test-data_illegalcharacter.csv"),
+        ("test-pid-utf-8-decode-errors", "test-data_illegalcharacter.csv"),
     ]
 
     # For ease of adding test data, we are using the same sysmeta which is not tested against

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@
 import os
 import pytest
 from hashstore import HashStoreFactory
+from metadig import MetaDigClientUtilities
+
+@pytest.fixture(name="mcdu")
+def init_metadig_client_utilities():
+    """Create and return the path to a hashstore"""
+    return MetaDigClientUtilities()
+
 
 @pytest.fixture(name="store_path")
 def init_store_path(tmp_path):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -326,10 +326,10 @@ def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test
     """Confirm that 'detect_text_encoding' reads the bytes as expected."""
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
-    pid = "test-pid-decode-errors"
+    pid = "test-pid-utf-8-decode-errors"
     obj, _ = manager.get_object(pid)
     bytes_read = obj.read()
 
     enc_type, msg = metadata.detect_text_encoding(bytes_read)
-    assert enc_type == "other"
+    assert enc_type == "ISO-8859-1"
     assert "decode error at" in msg

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -83,7 +83,6 @@ def test_get_data_object_system_metadata():
     identifier = "doi:10.18739/A24F1MM18"
     mn_url = "urn:node:ARCTIC"
 
-    mdcu = MetaDigClientUtilities()
-    mdcu.get_data_object_system_metadata(identifier, mn_url)
+    MetaDigClientUtilities.get_data_object_system_metadata(identifier, mn_url)
 
     # TODO: Assert the data retrieved is what we expect it to be (no errors)

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -114,7 +114,8 @@ def test_get_data_object_system_metadata(mcdu):
     auth_mn_node = "urn:node:ARCTIC"
 
     data_obj_name, sysmeta = mcdu.get_data_object_system_metadata(
-        identifier, auth_mn_node
+        identifier,
+        auth_mn_node,
     )
 
     assert data_obj_name == "Ground_Temperature_Monitoring_of_a_Cover_Crop_Vari.xml"
@@ -131,12 +132,27 @@ def test_find_file(mcdu):
     assert data_object_path is not None
 
 
-def test_import_data_to_hashstore(mcdu):
+def test_import_data_to_hashstore_default_store(mcdu):
     """Test that 'import_data_to_hashstore' imports data to the default hashstore."""
     sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
     test_data_directory = os.path.join(os.path.dirname(__file__), "testdata")
 
     data_pids_stored = mcdu.import_data_to_hashstore(sample_sysmeta_file_path, test_data_directory)
+    for pid in data_pids_stored:
+        # No exceptions should be thrown if the data objects and system metadata were stored
+        mcdu.default_store.delete_object(pid)
+        mcdu.default_store.delete_metadata(pid)
+
+
+def test_import_data_to_hashstore_provided_store(mcdu, store_path, init_hashstore_with_test_data):
+    """Test that 'import_data_to_hashstore' imports data to a given hashstore."""
+    assert init_hashstore_with_test_data
+    sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
+    test_data_directory = os.path.join(os.path.dirname(__file__), "testdata")
+
+    data_pids_stored = mcdu.import_data_to_hashstore(
+        sample_sysmeta_file_path, test_data_directory, store_path
+    )
     for pid in data_pids_stored:
         # No exceptions should be thrown if the data objects and system metadata were stored
         mcdu.default_store.delete_object(pid)

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -4,6 +4,7 @@ import sys
 import json
 import pytest
 from metadig import metadigclient
+from metadig import MetaDigClientUtilities
 
 def test_metadig_client_run_check(capsys, store, init_hashstore_with_test_data):
     """Confirm metadig runs a check successfully"""
@@ -72,3 +73,17 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
 
     with pytest.raises(ValueError):
         metadigclient.main()
+
+
+# MetaDigClientUtilities Tests
+
+
+def test_get_data_object_system_metadata():
+    """Check that we can retrieve a data object's sysmeta."""
+    identifier = "doi:10.18739/A24F1MM18"
+    mn_url = "urn:node:ARCTIC"
+
+    mdcu = MetaDigClientUtilities()
+    mdcu.get_data_object_system_metadata(identifier, mn_url)
+
+    # TODO: Assert the data retrieved is what we expect it to be (no errors)

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -81,10 +81,10 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
 def test_get_data_object_system_metadata():
     """Check that we can retrieve a data object's sysmeta and parse it for the file name."""
     identifier = "doi:10.18739/A24F1MM18"
-    mn_url = "urn:node:ARCTIC"
+    auth_mn_node = "urn:node:ARCTIC"
 
     data_obj_name, sysmeta = MetaDigClientUtilities.get_data_object_system_metadata(
-        identifier, mn_url
+        identifier, auth_mn_node
     )
 
     assert data_obj_name == "Ground_Temperature_Monitoring_of_a_Cover_Crop_Vari.xml"

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -79,10 +79,13 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
 
 
 def test_get_data_object_system_metadata():
-    """Check that we can retrieve a data object's sysmeta."""
+    """Check that we can retrieve a data object's sysmeta and parse it for the file name."""
     identifier = "doi:10.18739/A24F1MM18"
     mn_url = "urn:node:ARCTIC"
 
-    MetaDigClientUtilities.get_data_object_system_metadata(identifier, mn_url)
+    data_obj_name, sysmeta = MetaDigClientUtilities.get_data_object_system_metadata(
+        identifier, mn_url
+    )
 
-    # TODO: Assert the data retrieved is what we expect it to be (no errors)
+    assert data_obj_name == "Ground_Temperature_Monitoring_of_a_Cover_Crop_Vari.xml"
+    assert sysmeta is not None

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -4,7 +4,7 @@ import sys
 import json
 import pytest
 from metadig import metadigclient
-from metadig import MetaDigClientUtilities
+
 
 def test_metadig_client_run_check(capsys, store, init_hashstore_with_test_data):
     """Confirm metadig runs a check successfully"""
@@ -78,14 +78,24 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
 # MetaDigClientUtilities Tests
 
 
-def test_get_data_object_system_metadata():
+def test_get_data_object_system_metadata(mcdu):
     """Check that we can retrieve a data object's sysmeta and parse it for the file name."""
     identifier = "doi:10.18739/A24F1MM18"
     auth_mn_node = "urn:node:ARCTIC"
 
-    data_obj_name, sysmeta = MetaDigClientUtilities.get_data_object_system_metadata(
+    data_obj_name, sysmeta = mcdu.get_data_object_system_metadata(
         identifier, auth_mn_node
     )
 
     assert data_obj_name == "Ground_Temperature_Monitoring_of_a_Cover_Crop_Vari.xml"
     assert sysmeta is not None
+
+
+def test_find_file(mcdu):
+    """Check that 'find_file' can find a file in a given folder"""
+    # Current directory
+    folder_to_check = os.path.join(os.path.dirname(__file__))
+    file_to_find = "resource.license.present-2.0.0.xml"
+
+    data_object_path = mcdu.find_file(folder_to_check, file_to_find)
+    assert data_object_path is not None

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -6,6 +6,12 @@ import pytest
 from metadig import metadigclient
 
 
+def get_test_data_path(file_name):
+    """Get the path to a test file in tests/testdata"""
+    test_data_directory = os.path.join(os.path.dirname(__file__), "testdata")
+    return os.path.join(test_data_directory, file_name)
+
+
 def test_metadig_client_run_check(capsys, store, init_hashstore_with_test_data):
     """Confirm metadig runs a check successfully"""
     assert init_hashstore_with_test_data
@@ -92,10 +98,23 @@ def test_get_data_object_system_metadata(mcdu):
 
 
 def test_find_file(mcdu):
-    """Check that 'find_file' can find a file in a given folder"""
+    """Check that 'find_file' can find a data file that's in a subfolder in a given folder."""
     # Current directory
     folder_to_check = os.path.join(os.path.dirname(__file__))
     file_to_find = "resource.license.present-2.0.0.xml"
 
     data_object_path = mcdu.find_file(folder_to_check, file_to_find)
     assert data_object_path is not None
+
+
+def test_import_data_to_hashstore(mcdu):
+    """Test that 'import_data_to_hashstore' imports data to the default hashstore."""
+    sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
+    test_data_directory = os.path.join(os.path.dirname(__file__), "testdata")
+
+    data_pids_stored = mcdu.import_data_to_hashstore(sample_sysmeta_file_path, test_data_directory)
+    for pid in data_pids_stored:
+        obj_stream = mcdu.default_store.retrieve_object(pid)
+        sysmeta_stream = mcdu.default_store.retrieve_metadata(pid)
+        obj_stream.close()
+        sysmeta_stream.close()

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -115,7 +115,5 @@ def test_import_data_to_hashstore(mcdu):
     data_pids_stored = mcdu.import_data_to_hashstore(sample_sysmeta_file_path, test_data_directory)
     for pid in data_pids_stored:
         # No exceptions should be thrown if the data objects and system metadata were stored
-        obj_stream = mcdu.default_store.retrieve_object(pid)
-        sysmeta_stream = mcdu.default_store.retrieve_metadata(pid)
-        obj_stream.close()
-        sysmeta_stream.close()
+        mcdu.default_store.delete_object(pid)
+        mcdu.default_store.delete_metadata(pid)

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -114,6 +114,7 @@ def test_import_data_to_hashstore(mcdu):
 
     data_pids_stored = mcdu.import_data_to_hashstore(sample_sysmeta_file_path, test_data_directory)
     for pid in data_pids_stored:
+        # No exceptions should be thrown if the data objects and system metadata were stored
         obj_stream = mcdu.default_store.retrieve_object(pid)
         sysmeta_stream = mcdu.default_store.retrieve_metadata(pid)
         obj_stream.close()

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -81,6 +81,30 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
         metadigclient.main()
 
 
+def test_metadig_client_import_data_to_hashstore(capsys):
+    """Confirm that the metadig client imports data to hashstore successfully."""
+    client_directory = os.getcwd() + "/metadig"
+    client_module_path = f"{client_directory}/metadigclient.py"
+    test_dir = "tests/testdata/"
+    import_hashstore_opt = "-importhashstoredata"
+    sysmeta_doc_path_opt = f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml"
+    data_folder_opt = f"-data_folder={test_dir}"
+
+    chs_args = [
+        client_module_path,
+        import_hashstore_opt,
+        sysmeta_doc_path_opt,
+        data_folder_opt
+    ]
+
+    sys.path.append(client_directory)
+    sys.argv = chs_args
+    metadigclient.main()
+
+    result_data = capsys.readouterr().out
+    assert "Data objects have been stored for pids" in result_data
+
+
 # MetaDigClientUtilities Tests
 
 

--- a/tests/testdata/checks/data.character-encoding.xml
+++ b/tests/testdata/checks/data.character-encoding.xml
@@ -58,8 +58,10 @@ def call():
             output_data.append(f"{fname} is a valid 'utf-8' document and does not contain encoding errors.")
             output_type.append("text")
             status_data.append("SUCCESS")
-        elif enc_type == "other":
-            output_data.append(f"Cannot determine type of {fname}. Additional details: {msg}.")
+        else:
+            # TODO: For now, we will only accept valid 'utf-8' and 'ascii' documents as a SUCCESS
+            #       Discuss if we should have specific standards, or should proceed in another path
+            output_data.append(f"{fname} has been detected as a '{enc_type}' document, and may contain errors: {msg}.")
             output_type.append("text")
             status_data.append("FAILURE")
 

--- a/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
@@ -18,7 +18,7 @@ def call():
     global metadigpy_result
 
     from metadig import StoreManager
-    import metadig as md
+    from metadig import metadata as md
     import pandas as pd
     import io
 
@@ -52,42 +52,37 @@ def call():
             status_data.append("FAILURE")
             continue
 
-        # read in all the data
-        d_read = obj.read().decode('utf-8', errors = 'replace')
-
-        # find which entity file is documented in
-        index_list = md.find_entity_index(fname, pid, entityNames, ids)
-        if index_list is None:
+        # Ensure that the data object is documented in the list of entity names
+        entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
+        if entity_index is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        # Set entity index number to the first item in the list
-        z = index_list[0]
 
-        # Set default value using the entity index
-        num_header_lines = z
+        # Set the default expecated header line value (the first row is headers)
+        num_header_lines = 1
         # headerLines represents 'numHeaderLines' which is retrieved from the EML document
         if isinstance(headerLines, list):
             # If we successfully retrieve a list, we will check what the value is
-            if headerLines[z] == 'null':
+            if headerLines[entity_index] == 'null':
                 # There are no header lines
                 num_header_lines = 0
-            if isinstance(headerLines[z], int):
+            if isinstance(headerLines[entity_index], int):
                 # We'll use the value from the list of it is an integer
-                num_header_lines = headerLines[z]
+                num_header_lines = headerLines[entity_index]
         
         # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
+        obj_bytes_read = obj.read()
+        encoding_type, enc_msg = md.detect_text_encoding(obj_bytes_read)
+        d_read_decoded = obj_bytes_read.decode(encoding_type)
+        df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
-            error_msg = (
-              f"{fname} is unable to be read as a table: {error}."
-              + f" Debug Info: entity index z: {z}. headerLines: {headerLines}"
-            )
-            output_data.append(error_msg)
+            output_data.append(f"{fname} is unable to be read as a table: {error}.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
+
 
         colnames = list(df.columns)
         # extract the entity from the metadata doc and attributeNames
@@ -99,8 +94,16 @@ def call():
             output_type.append("text")
             status_data.append("SUCCESS")
         else:
-            output_data.append(f"{fname} variable names do not match documentation. Attribute names: {att_names}. Variable names: {colnames}")
-            output_type.append("text")
+            # Create a nice table to compare the variable names
+            table_rows = [
+                "| Attribute Names (Expected) | Variable Names (CSV) |",
+                "|----------------------------|----------------------|"
+            ]
+            for att, col in zip(att_names, colnames):
+                table_rows.append(f"| {att} | {col} |")
+            joined_table_rows = '\n'.join(table_rows)
+            output_data.append(f"{fname} variable names do not match documentation.\n{joined_table_rows}")
+            output_type.append("markdown")
             status_data.append("FAILURE")
 
     successes = sum(x == "SUCCESS" for x in status_data)


### PR DESCRIPTION
**Summary of Changes:**
- Added a default hashstore to ship with the `metadig-py` repo, that is the default store to use when working with data and system metadata with the `metadigclient`
    - Updated `.gitignore` to not track any of the data objects or system metadata stored
- Added a new utility class **MetaDigClientUtilities** to the `metadigclient` module and added pytests
    - Added new function `import_data_to_hashstore` that takes a given folder and an eml metadata sysmeta document to import data objects into the default (or given) hashstore.
    - Updated the `metadigclient` module arguments to allow importing of data objects to a hashstore through the client
- Refactored `get_data_pids` function in `checks` module - redundant encode/decode calls
- Refactored `read_csv_with_metadata` in the `metadata` module to accept and use an encoding if provided to read a .csv
- Refactored `detect_text_encoding` in the `metadata` module to return a specific encoding if it's not `ascii` or `utf-8`
- Renamed a testdata document to be accurate with how its document in its respective eml document
- Updated data checks for `variables-congruent` and `data-encoding`