### PR TITLE
Feature-37: Add functionality to `run_suite` through the `metadigclient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ $ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
 
 (metadigpy) ~/Code/hashstore $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 
-(metadigpy) ~/Code/hashstore $ {'identifiers': ['...', '...'], 'output': ["the_dataset_checked.csv is a valid 'utf-8' document and does not contain encoding errors."], 'status': 'SUCCESS'}
+{'identifiers': ['...', '...'], 'output': ["the_dataset_checked.csv is a valid 'utf-8' document and does not contain encoding errors."], 'status': 'SUCCESS'}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,8 +19,57 @@ for their [`metadig-checks`](https://github.com/NCEAS/metadig-checks). By import
 package, users get access to all available helper functions and classes, such as `object_store.py`
 which enables users to write checks that efficiently retrieves data objects to work with.
 
+## Installation
 
-## How do I run a check suite (ex. FAIR-suite-0.4.0.xml)
+To install MetaDIG-py, run the following commands
+
+```sh
+$ mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
+(metadigpy) $ poetry install # Run poetry command to install dependencies
+```
+- Note: If you run into an issue with installing jep, it is likely due to a backwards
+compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
+  ```sh
+  (metadigpy) $ pip install setuptools==58.0.0
+  ```
+
+To confirm that you have installed `MetaDIG-py` successfully, run `pytest`.
+```sh
+(metadigpy) $ pytest
+```
+- Tip: You may run `pytest` with the option `-s` (ex. `pytest -s`) to see print statements. Not all pytests have print statements, but if you want to extend from what already exists, this may prove to be helpful!
+
+## How do I import the `MetaDIG-py` library?
+
+In your python code, you can import a specific module or function like such:
+
+```py
+from metadig import read_sysmeta_element
+from metadig import MetaDigClientUtilities as mcdu
+```
+
+Currently, we have the following modules and functions available:
+
+```py
+"StoreManager", # Class to work with a HashStore
+"getType", # fn
+"isResolvable", # fn
+"isBlank", # fn
+"toUnicode", # fn
+"read_sysmeta_element", # fn
+"find_eml_entity", # fn
+"find_entity_index", # fn
+"read_csv_with_metadata", # fn
+"get_valid_csv", # fn
+"detect_text_encoding", # fn
+"run_check", # fn
+"checks", # Module
+"metadata", # Module
+"suites", # Module
+"MetaDigClientUtilities", = # Module
+```
+
+## How do I run an entire check suite (ex. FAIR-suite-0.4.0.xml)?
 
 To run a suite, you must have the path to the suite to run, a path to the folder containing all the checks, the metadata file path and the path to the metadata's system metadata.
 
@@ -31,7 +80,7 @@ suite_file_path = "/path/to/FAIR-suite-0.4.0.xml"
 checks_path = "path/to/folder/containing/checks"
 metadata_file_path = "path/to/metadata:data_file.xml"
 sysmeta_file_path = "path/to/metadata:data_sysmeta_file.xml"
-# Note: storemanager_props are only relevant if you are executing data checks and has a default value of 'None'
+# Note: storemanager_props are only relevant if you are executing data checks and has a default value of 'None'. In the example below, we intentionally do not supply an argument for storemanager_props because the 'fair-suite' does not require data objects.
 
 suite_results = suites.run_suite(
     suite_path,
@@ -102,7 +151,7 @@ print(suite_results)
 ```
 
 
-## How do I run a metadata check?
+## How do I run a single metadata check?
 
 To run a metadata check, pass the check.xml, metadata file path and metadata's system metadata's file path to the `run_check` function.
 
@@ -126,52 +175,7 @@ print(result)
 }
 ```
 
-## How do I import the `MetaDIG-py` library to my check?
-
-In your python code, you can import a specific module or function like such:
-
-```py
-from metadig import read_sysmeta_element
-```
-
-Currently, we have the following modules and functions available:
-
-```py
-"StoreManager", # fn
-"getType", # fn
-"isResolvable", # fn
-"isBlank", # fn
-"toUnicode", # fn
-"read_sysmeta_element", # fn
-"find_eml_entity", # fn
-"find_entity_index", # fn
-"read_csv_with_metadata", # fn
-"get_valid_csv", # fn
-"run_check", # fn
-"checks" # Module
-```
-
-## Installation
-
-To install MetaDIG-py, run the following commands
-
-```sh
-$ mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
-(metadigpy) $ poetry install # Run poetry command to install dependencies
-```
-- Note: If you run into an issue with installing jep, it is likely due to a backwards
-compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
-  ```sh
-  (metadigpy) $ pip install setuptools==58.0.0
-  ```
-
-To confirm that you have installed `MetaDIG-py` successfully, run `pytest`.
-```sh
-(metadigpy) $ pytest
-```
-- Tip: You may run `pytest` with the option `-s` (ex. `pytest -s`) to see print statements. Not all pytests have print statements, but if you want to extend from what already exists, this may prove to be helpful!
-
-### How to use the MetaDIG-py command line client
+## How to use the MetaDIG-py command line client
 
 The MetaDIG-py command line client was created to help users test python checks without having to spin up the java engine `metadig-engine` and run a check through the dispatcher.
 
@@ -181,20 +185,19 @@ After you've installed `MetaDIG-py`, you will have access to the command `metadi
 (metadigpy) $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 ```
 
-### How does the MetaDIG-py command line client run a check or suite with the arguments supplied?
+To get help and see all the options available, you can run metadigpy with the `-h` flag
 
-The `metadigclient` extracts the identifier (ex. DOI) & the authoritative member node (MN) (e.g. `urn:node:ARCTIC`) from the system metadata document supplied for the given eml metadata document. It then passes these values to the `run_check` or `run_suite` function, which retrieves the associated data pids and their respective system metadata from the given hashstore.
-
-Afterwards, `metadigpy` then parses the check xml provided or the suite and check paths, validates and executes the check, and lastly prints the final result to stdout. `run_check` will return the results of a specific check, and `run_suite` will return the results of all the checks found in the given suite.
+```sh
+(metadigpy) $ metadigpy -h
+```
 
 ### How to set up and run a data check through the MetaDig-py command line client
 
 To set up a data check, you must have/prepare the following before you run the `metadigpy` client command (above)
-1) A HashStore - this step is necessary because `run_check` will look for the data objects in a HashStore after retrieving the data pids.
-    - If you do not have a hashstore, `metadigpy` ships with a default hashstore that is ready to use.
-2) The data objects associated with the DOI to check stored in HashStore, including the data objects' system metadata.
+1) A HashStore - note, `metadigpy` ships with a default hashstore that is ready to use.
+2) The data objects stored into the hashstore
 2) A copy of the metadata document and its respective system metadata for the DOI.
-4) The check you want to run
+4) The suite and/or checks you want to run
 
 #### What is HashStore?
 
@@ -259,7 +262,7 @@ $ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
 
 (metadigpy) ~/Code/hashstore $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 
-(metadigpy) ~/Code/hashstore $ {'Check Status': 0, 'Check Result': ['...RESULT...']}
+(metadigpy) ~/Code/hashstore $ {'identifiers': ['...', '...'], 'output': ["the_dataset_checked.csv is a valid 'utf-8' document and does not contain encoding errors."], 'status': 'SUCCESS'}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -181,21 +181,17 @@ After you've installed `MetaDIG-py`, you will have access to the command `metadi
 (metadigpy) $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 ```
 
-### How does the MetaDIG-py command line client run a check with the arguments supplied?
+### How does the MetaDIG-py command line client run a check or suite with the arguments supplied?
 
-The `metadigclient` extracts the identifier (ex. DOI) & the authoritative member node (MN) (e.g. `urn:node:ARCTIC`) from the system metadata document supplied for the given eml metadata document. It then passes these values to the `run_check` function, which retrieves the associated data pids and their respective system metadata from the given hashstore.
+The `metadigclient` extracts the identifier (ex. DOI) & the authoritative member node (MN) (e.g. `urn:node:ARCTIC`) from the system metadata document supplied for the given eml metadata document. It then passes these values to the `run_check` or `run_suite` function, which retrieves the associated data pids and their respective system metadata from the given hashstore.
 
-The `run_check` function then parses the check xml provided, validates the check definition, executes the check, and lastly prints the final result to stdout. 
-
-As of writing this documentation, we have only set up the `metadigclient` to work with the following MN:
-- urn:node:ARCTIC
-
-To have additional nodes set up, please contact us at support@dataone.org
+Afterwards, `metadigpy` then parses the check xml provided or the suite and check paths, validates and executes the check, and lastly prints the final result to stdout. `run_check` will return the results of a specific check, and `run_suite` will return the results of all the checks found in the given suite.
 
 ### How to set up and run a data check through the MetaDig-py command line client
 
 To set up a data check, you must have/prepare the following before you run the `metadigpy` client command (above)
 1) A HashStore - this step is necessary because `run_check` will look for the data objects in a HashStore after retrieving the data pids.
+    - If you do not have a hashstore, `metadigpy` ships with a default hashstore that is ready to use.
 2) The data objects associated with the DOI to check stored in HashStore, including the data objects' system metadata.
 2) A copy of the metadata document and its respective system metadata for the DOI.
 4) The check you want to run

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -307,6 +307,7 @@ def main():
     import_hashstore_data = getattr(args, "import_hashstore_data")
     data_folder_path = getattr(args, "data_folder_path")
     check_folder_path = getattr(args, "check_folder_path")
+
     if run_check:
         if store_path is None:
             raise ValueError("'-store_path' arg is required to run a check")
@@ -326,7 +327,7 @@ def main():
         )
         print(result)
         return
-    if run_suite:
+    elif run_suite:
         if suite_path is None:
             raise ValueError("'-suite_path' arg is required to run a suite")
         if check_folder_path is None:
@@ -351,8 +352,7 @@ def main():
         )
         print(suite_results)
         return
-
-    if import_hashstore_data:
+    elif import_hashstore_data:
         if data_folder_path is None:
             raise ValueError("'-data_folder' arg is required to import hashstore data")
         if sysmeta_path is None:
@@ -366,6 +366,10 @@ def main():
         )
         print(f"Data objects have been stored for pids: {data_pids_stored}")
         return
+    else:
+        print(
+            "No options provided. Run `metadigpy -h` for more information."
+        )
 
 if __name__ == "__main__":
     main()

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -36,6 +36,12 @@ class MetaDigPyParser:
             help="Flag to run a check through the MetaDIG-py client",
         )
         self.parser.add_argument(
+            "-runsuite",
+            dest="run_suite",
+            action="store_true",
+            help="Flag to run a suite through the MetaDIG-py client",
+        )
+        self.parser.add_argument(
             "-importhashstoredata",
             dest="import_hashstore_data",
             action="store_true",

--- a/metadig/suites.py
+++ b/metadig/suites.py
@@ -120,10 +120,14 @@ def run_suite(
                     f"Check not found at path: {check_id_path}"
                 )
         else:
+            if check_env is None:
+                output_msg = f"Check not found for: {check_id} in: {checks_path}"
+            else:
+                output_msg = f"Incompatible check environment ({check_env}) for check: {check_id}."
             check_results.append({
                 "check_id": check_id,
                 "identifiers": "N/A",
-                "output": f"Incompatible check environment ({check_env}) for check: {check_id}.",
+                "output": output_msg,
                 "status": "ERROR",
             })
 

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -53,16 +53,16 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
     """Use pytest 'parametrize' decorator to efficiently test missing arguments"""
     client_directory = os.getcwd() + "/metadig"
     client_module_path = f"{client_directory}/metadigclient.py"
-    test_dir = "tests/testdata/"
+    test_dir = "tests/testdata"
     test_store_path = str(store.root)
     run_check_opt = "-runcheck"
 
     # Map options
     options = {
         "store_path": f"-store_path={test_store_path}",
-        "check_xml": f"-check_xml={test_dir}/data.table-text-delimited.glimpse.xml",
-        "metadata_doc": f"-metadata_doc={test_dir}/doi:10.18739_A2QJ78081.xml",
-        "sysmeta_doc": f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml",
+        "check_xml": f"-check_xml={test_dir}data.table-text-delimited.glimpse.xml",
+        "metadata_doc": f"-metadata_doc={test_dir}doi:10.18739_A2QJ78081.xml",
+        "sysmeta_doc": f"-sysmeta_doc={test_dir}doi:10.18739_A2QJ78081_sysmeta.xml",
     }
 
     # Remove the missing option dynamically by creating a new list that excludes the missing opt
@@ -85,7 +85,7 @@ def test_metadig_client_import_data_to_hashstore(capsys):
     """Confirm that the metadig client imports data to hashstore successfully."""
     client_directory = os.getcwd() + "/metadig"
     client_module_path = f"{client_directory}/metadigclient.py"
-    test_dir = "tests/testdata/"
+    test_dir = "tests/testdata"
     import_hashstore_opt = "-importhashstoredata"
     sysmeta_doc_path_opt = f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml"
     data_folder_opt = f"-data_folder={test_dir}"
@@ -104,6 +104,41 @@ def test_metadig_client_import_data_to_hashstore(capsys):
     result_data = capsys.readouterr().out
     assert "Data objects have been stored for pids" in result_data
 
+
+def test_metadig_client_run_suite(capsys, store, init_hashstore_with_test_data):
+    """Confirm metadig runs a check successfully"""
+    assert init_hashstore_with_test_data
+    client_directory = os.getcwd() + "/metadig"
+    client_module_path = f"{client_directory}/metadigclient.py"
+    test_dir = "tests/testdata"
+    test_store_path = str(store.root)
+    run_check_opt = "-runsuite"
+    hashstore_path_opt = f"-store_path={test_store_path}"
+    suite_path_opt = f"-suite_path={test_dir}/data-suite.xml"
+    check_folder_path_opt = f"-check_folder={test_dir}/checks/"
+    metadata_doc_path_opt = f"-metadata_doc={test_dir}/doi:10.18739_A2QJ78081.xml"
+    sysmeta_doc_path_opt = f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml"
+
+    chs_args = [
+        client_module_path,
+        run_check_opt,
+        hashstore_path_opt,
+        suite_path_opt,
+        check_folder_path_opt,
+        metadata_doc_path_opt,
+        sysmeta_doc_path_opt
+    ]
+
+    sys.path.append(client_directory)
+    sys.argv = chs_args
+    metadigclient.main()
+
+    result_data = json.loads(capsys.readouterr().out)
+    assert result_data is not None
+    assert result_data["suite"] == "data-suite.xml"
+    assert result_data["sysmeta"] is not None
+    assert result_data["run_status"] == "SUCCESS"
+    assert result_data["results"] is not None
 
 # MetaDigClientUtilities Tests
 


### PR DESCRIPTION
**Summary of Changes:**
- Added code to the `metadig-py` command line client to run a suite and pytests
- Improved `run_suite` function output messaging to provide details around when a check cannot be found
- Updated & re-organized documentation to reflect the most recent changes