### PR TITLE
metadig-py 3.1.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ ENV/
 # Rope project settings
 .ropeproject
 .vscode/settings.json
+
+# HashStore settings
+# Allow hashstore/ and its immediate subfolders
+hashstore/*

--- a/README.md
+++ b/README.md
@@ -19,8 +19,57 @@ for their [`metadig-checks`](https://github.com/NCEAS/metadig-checks). By import
 package, users get access to all available helper functions and classes, such as `object_store.py`
 which enables users to write checks that efficiently retrieves data objects to work with.
 
+## Installation
 
-## How do I run a check suite (ex. FAIR-suite-0.4.0.xml)
+To install MetaDIG-py, run the following commands
+
+```sh
+$ mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
+(metadigpy) $ poetry install # Run poetry command to install dependencies
+```
+- Note: If you run into an issue with installing jep, it is likely due to a backwards
+compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
+  ```sh
+  (metadigpy) $ pip install setuptools==58.0.0
+  ```
+
+To confirm that you have installed `MetaDIG-py` successfully, run `pytest`.
+```sh
+(metadigpy) $ pytest
+```
+- Tip: You may run `pytest` with the option `-s` (ex. `pytest -s`) to see print statements. Not all pytests have print statements, but if you want to extend from what already exists, this may prove to be helpful!
+
+## How do I import the `MetaDIG-py` library?
+
+In your python code, you can import a specific module or function like such:
+
+```py
+from metadig import read_sysmeta_element
+from metadig import MetaDigClientUtilities as mcdu
+```
+
+Currently, we have the following modules and functions available:
+
+```py
+"StoreManager", # Class to work with a HashStore
+"getType", # fn
+"isResolvable", # fn
+"isBlank", # fn
+"toUnicode", # fn
+"read_sysmeta_element", # fn
+"find_eml_entity", # fn
+"find_entity_index", # fn
+"read_csv_with_metadata", # fn
+"get_valid_csv", # fn
+"detect_text_encoding", # fn
+"run_check", # fn
+"checks", # Module
+"metadata", # Module
+"suites", # Module
+"MetaDigClientUtilities", = # Module
+```
+
+## How do I run an entire check suite (ex. FAIR-suite-0.4.0.xml)?
 
 To run a suite, you must have the path to the suite to run, a path to the folder containing all the checks, the metadata file path and the path to the metadata's system metadata.
 
@@ -31,7 +80,7 @@ suite_file_path = "/path/to/FAIR-suite-0.4.0.xml"
 checks_path = "path/to/folder/containing/checks"
 metadata_file_path = "path/to/metadata:data_file.xml"
 sysmeta_file_path = "path/to/metadata:data_sysmeta_file.xml"
-# Note: storemanager_props are only relevant if you are executing data checks and has a default value of 'None'
+# Note: storemanager_props are only relevant if you are executing data checks and has a default value of 'None'. In the example below, we intentionally do not supply an argument for storemanager_props because the 'fair-suite' does not require data objects.
 
 suite_results = suites.run_suite(
     suite_path,
@@ -102,7 +151,7 @@ print(suite_results)
 ```
 
 
-## How do I run a metadata check?
+## How do I run a single metadata check?
 
 To run a metadata check, pass the check.xml, metadata file path and metadata's system metadata's file path to the `run_check` function.
 
@@ -126,54 +175,9 @@ print(result)
 }
 ```
 
-## How do I import the `MetaDIG-py` library to my check?
+## How to use the MetaDIG-py command line client
 
-In your python code, you can import a specific module or function like such:
-
-```py
-from metadig import read_sysmeta_element
-```
-
-Currently, we have the following modules and functions available:
-
-```py
-"StoreManager", # fn
-"getType", # fn
-"isResolvable", # fn
-"isBlank", # fn
-"toUnicode", # fn
-"read_sysmeta_element", # fn
-"find_eml_entity", # fn
-"find_entity_index", # fn
-"read_csv_with_metadata", # fn
-"get_valid_csv", # fn
-"run_check", # fn
-"checks" # Module
-```
-
-## Installation
-
-To install MetaDIG-py, run the following commands
-
-```sh
-$ mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
-(metadigpy) $ poetry install # Run poetry command to install dependencies
-```
-- Note: If you run into an issue with installing jep, it is likely due to a backwards
-compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
-  ```sh
-  (metadigpy) $ pip install setuptools==58.0.0
-  ```
-
-To confirm that you have installed `MetaDIG-py` successfully, run `pytest`.
-```sh
-(metadigpy) $ pytest
-```
-- Tip: You may run `pytest` with the option `-s` (ex. `pytest -s`) to see print statements. Not all pytests have print statements, but if you want to extend from what already exists, this may prove to be helpful!
-
-### How to use the MetaDIG-py command line client
-
-The MetaDIG-py command line client was created to help users test python checks without having to spin up the java engine `metadig-engine` and run a check through the dispatcher.
+The `MetaDIG-py` command line client was created to help users test python checks without having to spin up the java engine `metadig-engine` and run a check through the dispatcher.
 
 After you've installed `MetaDIG-py`, you will have access to the command `metadigpy`. Please see installation section above if you haven't installed `MetaDIG-py`. Below is what running a check looks like:
 
@@ -181,28 +185,34 @@ After you've installed `MetaDIG-py`, you will have access to the command `metadi
 (metadigpy) $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 ```
 
-### How does the MetaDIG-py command line client run a check with the arguments supplied?
+To get help and see all the options available, you can run metadigpy with the `-h` flag
 
-The `metadigclient` extracts the identifier (ex. DOI) & the authoritative member node (MN) (e.g. `urn:node:ARCTIC`) from the system metadata document supplied for the given eml metadata document. It then passes these values to the `run_check` function, which retrieves the associated data pids and their respective system metadata from the given hashstore.
-
-The `run_check` function then parses the check xml provided, validates the check definition, executes the check, and lastly prints the final result to stdout. 
-
-As of writing this documentation, we have only set up the `metadigclient` to work with the following MN:
-- urn:node:ARCTIC
-
-To have additional nodes set up, please contact us at support@dataone.org
+```sh
+(metadigpy) $ metadigpy -h
+```
 
 ### How to set up and run a data check through the MetaDig-py command line client
 
 To set up a data check, you must have/prepare the following before you run the `metadigpy` client command (above)
-1) A HashStore - this step is necessary because `run_check` will look for the data objects in a HashStore after retrieving the data pids.
-2) The data objects associated with the DOI to check stored in HashStore, including the data objects' system metadata.
-2) A copy of the metadata document and its respective system metadata for the DOI.
-4) The check you want to run
+1) A HashStore - note, `MetaDig-py` ships with a default hashstore that is ready to use.
 
-#### What is HashStore?
+    Please see the section below to learn more.
 
-  * **Note**: A HashStore is only required if you are running data quality checks
+2) The data objects and their associated system metadata stored into the hashstore
+
+    During the `run_check` process, after retrieving the data pids for the provided identifier, we then retrieve their associated data objects and system metadata from the provided HashStore. If these 'files' are not found, it could cause errors with the check that you're trying to run or test. Note, every data object stored in HashStore must have an equivalent system metadata, and this system metadata describes the basic attributes of the data object.
+
+3) A copy of the metadata document and its respective system metadata for the DOI.
+
+    Every dataset not only has metadata about the dataset (which usually comes in the form of an EML metadata document) but also system metadata for the metadata. For us to run a `metadig` check at this time, we need both the metadata document and its respective system metadata. The system metadata is parsed for the identifier, which is then used to retrieve the appropriate data pids, which is then used in the check.
+
+4) The suite and/or checks you want to run
+
+    Suites and checks can be found in the `metadig-checks` repository. You may check this repo out and then provide the necessary paths for running a suite or check through the `metadigclient`.
+
+#### HashStore 101
+
+  * **Friendly Reminder**: A HashStore is only required if you are running data quality checks
 
 HashStore is a python package developed for DataONE services to efficiently access data objects, metadata and system metadata. In order to simulate the process of retrieving data objects with a `metadig` check, we must mimic the environment in which it happens in production. So the requirement of having a HashStore means that we need to create a HashStore and then store data objects and system metadata inside of it. Please see below for an example:
 
@@ -224,19 +234,61 @@ HashStore is a python package developed for DataONE services to efficiently acce
 
 On your file system, HashStore looks like a folder with data objects and system metadata stored with hashes based on either a content identifier, or a combination of values that create a unique identifier. To interact with a HashStore and learn more, please see the documentation [here](https://github.com/DataONEorg/hashstore/).
 
-#### Why data objects and its associated system metadata must be stored
+#### How do I use the default HashStore?
 
-During the `run_check` process, after retrieving the data pids for the provided identifier, we then retrieve their associated data objects and system metadata from the provided HashStore. If these 'files' are not found, it could cause errors with the check that you're trying to run or test. Note, every data object stored in HashStore must have an equivalent system metadata, and this system metadata describes the basic attributes of the data object.
+`MetaDig-py` ships with a hashstore that can be worked with directly through the command line, or through the `metadigclient`. If you do not provide a path to a hashstore to the `metadigclient`, its associated functions will attempt to search for data objects and sysmeta in the default hashstore found in `/hashstore`. You could also use the default hashstore path in the manual process should you desire to.
 
-#### Dataset Metadata + System Metadata
+##### How do I import my data objects to the default hashstore?
 
-Every dataset not only has metadata about the dataset (which usually comes in the form of an EML metadata document) but also system metadata for the metadata. For us to run a `metadig` check at this time, we need both the metadata document and its respective system metadata. The system metadata is parsed for the identifier, which is then used to retrieve the appropriate data pids, which is then used in the check.
+To import data to the default hashstore, you will need the system metadata document for the dataset metadata, and a folder that contains the data objects to import. This folder should contain data objects with the exact name of the data objects that are documented. 
 
-#### The Python Check
+This can be done by viewing your dataset on the member node url (ex. `https://arcticdata.io/catalog/view/doi:...`), downloading the dataset and then extracting its contents. You then copy this path and provide it to the `-data_folder` flag (an example can be found below).
 
-TODO: Discuss how a python check is created, and link to `metadig-checks` for more info.
+The `-importhashstoredata` process will parse the provided metadata system metadata document for the necessary details to validate, and then store the data objects and its associated system metadata to the default hashstore. 
 
-#### Example of the Entire Process via the `MetaDIG-py` command line client
+```sh
+(metadigpy) ~/Code/metadig-py $ metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
+```
+
+Now you may run your desired check or suite against the dataset you just imported to the default hashstore.
+
+## Example of the full `MetaDIG-py` command line client process to run a data suite (default hashstore)
+
+```sh
+$ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
+(metadigpy) ~/Code $ git clone https://github.com/NCEAS/metadig-py.git ~/Code/metadigpy
+
+(metadigpy) ~/Code $ cd /metadigpy
+
+(metadigpy) ~/Code/metadigpy $ poetry install // Run poetry command to install dependencies
+
+(metadigpy) ~/Code/metadigpy $ metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
+
+(metadigpy) ~/Code/hashstore $ metadigpy -runsuite -suite_path=/path/to/the/data-suite.xml -check_folder=path/to/the/folder/containing/checks/ -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
+
+{
+  "suite": "data-suite.xml",
+  "timestamp": "2025-06-04 12:04:52",
+  "object_identifier": "doi:10.18739/A2QJ70000",
+  "run_status": "SUCCESS",
+  "run_comments": [],
+  "sysmeta": {
+    "origin_member_node": "urn:node:ARCTIC",
+    "rights_holder": "http://orcid.org/0000-0000-0000-0000",
+    "date_uploaded": "2024-07-03T19:46:44.414+00:00",
+    "format_id": "https://eml.ecoinformatics.org/eml-2.2.0",
+    "obsoletes": "urn:uuid:..."
+  },
+  "results": [
+    {
+      ...
+    },
+    ...
+  ]
+}
+```
+
+## Example of the full `MetaDIG-py` command line client process to run a data check (manual hashstore)
 
 ```sh
 $ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
@@ -263,7 +315,7 @@ $ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
 
 (metadigpy) ~/Code/hashstore $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 
-(metadigpy) ~/Code/hashstore $ {'Check Status': 0, 'Check Result': ['...RESULT...']}
+{'identifiers': ['...', '...'], 'output': ["the_dataset_checked.csv is a valid 'utf-8' document and does not contain encoding errors."], 'status': 'SUCCESS'}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ poetry install # Run poetry command to install dependencies
 ```
 - Note: If you run into an issue with installing jep, it is likely due to a backwards
 compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
+
   ```sh
  pip install setuptools==58.0.0
   ```

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ which enables users to write checks that efficiently retrieves data objects to w
 To install MetaDIG-py, run the following commands
 
 ```sh
-$ mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
-(metadigpy) $ poetry install # Run poetry command to install dependencies
+mkvirtualenv -p python3.9 metadigpy # Create a virtual environment
+poetry install # Run poetry command to install dependencies
 ```
 - Note: If you run into an issue with installing jep, it is likely due to a backwards
 compatibility issue with `setuptools`. Try downgrading to the version 58.0.0:
   ```sh
-  (metadigpy) $ pip install setuptools==58.0.0
+ pip install setuptools==58.0.0
   ```
 
 To confirm that you have installed `MetaDIG-py` successfully, run `pytest`.
 ```sh
-(metadigpy) $ pytest
+pytest
 ```
 - Tip: You may run `pytest` with the option `-s` (ex. `pytest -s`) to see print statements. Not all pytests have print statements, but if you want to extend from what already exists, this may prove to be helpful!
 
@@ -182,13 +182,13 @@ The `MetaDIG-py` command line client was created to help users test python check
 After you've installed `MetaDIG-py`, you will have access to the command `metadigpy`. Please see installation section above if you haven't installed `MetaDIG-py`. Below is what running a check looks like:
 
 ```sh
-(metadigpy) $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
+metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 ```
 
 To get help and see all the options available, you can run metadigpy with the `-h` flag
 
 ```sh
-(metadigpy) $ metadigpy -h
+metadigpy -h
 ```
 
 ### How to set up and run a data check through the MetaDig-py command line client
@@ -218,18 +218,18 @@ HashStore is a python package developed for DataONE services to efficiently acce
 
 ```sh
 # Step 0: Install hashstore via poetry to create an executable script
-(metadigpy) ~/Code $ git clone https://github.com/DataONEorg/hashstore.git /Code/hashstore
+git clone https://github.com/DataONEorg/hashstore.git /Code/hashstore
 
-(metadigpy) ~/Code/hashstore $ poetry install
+poetry install
 
 # Step 1: Create a HashStore at your desired store path (ex. /var/metacat/hashstore)
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -chs -dp=3 -wp=2 -ap=SHA-256 -nsp="https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+hashstore /path/to/store/ -chs -dp=3 -wp=2 -ap=SHA-256 -nsp="https://ns.dataone.org/service/types/v2.0#SystemMetadata"
 
 # Store a data object
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -storeobject -pid=persistent_identifier -path=/path/to/object
+hashstore /path/to/store/ -storeobject -pid=persistent_identifier -path=/path/to/object
 
 # Store a metadata object
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
+hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
 ```
 
 On your file system, HashStore looks like a folder with data objects and system metadata stored with hashes based on either a content identifier, or a combination of values that create a unique identifier. To interact with a HashStore and learn more, please see the documentation [here](https://github.com/DataONEorg/hashstore/).
@@ -247,7 +247,7 @@ This can be done by viewing your dataset on the member node url (ex. `https://ar
 The `-importhashstoredata` process will parse the provided metadata system metadata document for the necessary details to validate, and then store the data objects and its associated system metadata to the default hashstore. 
 
 ```sh
-(metadigpy) ~/Code/metadig-py $ metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
+metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
 ```
 
 Now you may run your desired check or suite against the dataset you just imported to the default hashstore.
@@ -255,16 +255,16 @@ Now you may run your desired check or suite against the dataset you just importe
 ## Example of the full `MetaDIG-py` command line client process to run a data suite (default hashstore)
 
 ```sh
-$ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
-(metadigpy) ~/Code $ git clone https://github.com/NCEAS/metadig-py.git ~/Code/metadigpy
+mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
+git clone https://github.com/NCEAS/metadig-py.git ~/Code/metadigpy
 
-(metadigpy) ~/Code $ cd /metadigpy
+cd /metadigpy
 
-(metadigpy) ~/Code/metadigpy $ poetry install // Run poetry command to install dependencies
+poetry install // Run poetry command to install dependencies
 
-(metadigpy) ~/Code/metadigpy $ metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
+metadigpy -importhashstoredata -sysmeta_doc=/path/to/sysmeta -data_folder=/path/to/datset/folder/with/data/objects
 
-(metadigpy) ~/Code/hashstore $ metadigpy -runsuite -suite_path=/path/to/the/data-suite.xml -check_folder=path/to/the/folder/containing/checks/ -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
+metadigpy -runsuite -suite_path=/path/to/the/data-suite.xml -check_folder=path/to/the/folder/containing/checks/ -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 
 {
   "suite": "data-suite.xml",
@@ -291,29 +291,29 @@ $ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
 ## Example of the full `MetaDIG-py` command line client process to run a data check (manual hashstore)
 
 ```sh
-$ mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
-(metadigpy) ~/Code $ git clone https://github.com/NCEAS/metadig-py.git ~/Code/metadigpy
+mkvirtualenv -p python3.9 metadigpy // Create a virtual environment
+git clone https://github.com/NCEAS/metadig-py.git ~/Code/metadigpy
 
-(metadigpy) ~/Code $ cd /metadigpy
+cd /metadigpy
 
-(metadigpy) ~/Code/metadigpy $ poetry install // Run poetry command to install dependencies
+poetry install // Run poetry command to install dependencies
 
-(metadigpy) ~/Code/metadigpy $ git clone https://github.com/DataONEorg/hashstore.git ~/Code/hashstore
+git clone https://github.com/DataONEorg/hashstore.git ~/Code/hashstore
 
-(metadigpy) ~/Code $ cd ../hashstore
+cd ../hashstore
 
-(metadigpy) ~/Code/hashstore $ poetry install
+poetry install
 
 # Step 1: Create a HashStore at your desired store path (ex. /var/metacat/hashstore)
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -chs -dp=3 -wp=2 -ap=SHA-256 -nsp="https://ns.dataone.org/service/types/v2.0#SystemMetadata"
+hashstore /path/to/store/ -chs -dp=3 -wp=2 -ap=SHA-256 -nsp="https://ns.dataone.org/service/types/v2.0#SystemMetadata"
 
 # Store a data object
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -storeobject -pid=persistent_identifier -path=/path/to/object
+hashstore /path/to/store/ -storeobject -pid=persistent_identifier -path=/path/to/object
 
 # Store a metadata object
-(metadigpy) ~/Code/hashstore $ hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
+hashstore /path/to/store/ -storemetadata -pid=persistent_identifier -path=/path/to/metadata/object -formatid=https://ns.dataone.org/service/types/v2.0#SystemMetadata
 
-(metadigpy) ~/Code/hashstore $ metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
+metadigpy -runcheck -store_path=/path/to/hashstore -check_xml=/path/to/check_xml -metadata_doc=/path/to/metadata/doc -sysmeta_doc=/path/to/sysmeta
 
 {'identifiers': ['...', '...'], 'output': ["the_dataset_checked.csv is a valid 'utf-8' document and does not contain encoding errors."], 'status': 'SUCCESS'}
 ```

--- a/hashstore/hashstore.yaml
+++ b/hashstore/hashstore.yaml
@@ -1,0 +1,45 @@
+
+# Default configuration variables for HashStore
+
+############### HashStore Config Notes ###############
+############### Directory Structure ###############
+# store_depth
+# - Desired amount of directories when sharding an object to form the permanent address
+# - **WARNING**: DO NOT CHANGE UNLESS SETTING UP NEW HASHSTORE
+#
+# store_width
+# - Width of directories created when sharding an object to form the permanent address
+# - **WARNING**: DO NOT CHANGE UNLESS SETTING UP NEW HASHSTORE
+#
+# Example:
+# Below, objects are shown listed in directories that are 3 levels deep (DIR_DEPTH=3),
+# with each directory consisting of 2 characters (DIR_WIDTH=2).
+#    /var/filehashstore/objects
+#    ├── 7f
+#    │   └── 5c
+#    │       └── c1
+#    │           └── 8f0b04e812a3b4c8f686ce34e6fec558804bf61e54b176742a7f6368d6
+
+############### Format of the Metadata ###############
+# store_metadata_namespace
+# - The default metadata format (ex. system metadata)
+
+############### Hash Algorithms ###############
+# store_algorithm
+# - Hash algorithm to use when calculating object's hex digest for the permanent address
+#
+# store_default_algo_list
+# - Algorithm values supported by python hashlib 3.9.0+ for File Hash Store (FHS)
+# - The default algorithm list includes the hash algorithms calculated when storing an
+# - object to disk and returned to the caller after successful storage.
+
+store_depth: 3
+store_width: 2
+store_metadata_namespace: https://ns.dataone.org/service/types/v2.0#SystemMetadata
+store_algorithm: SHA-256
+store_default_algo_list:
+- MD5
+- SHA-1
+- SHA-256
+- SHA-384
+- SHA-512

--- a/metadig/__init__.py
+++ b/metadig/__init__.py
@@ -22,6 +22,8 @@ from .metadata import find_eml_entity
 from .metadata import find_entity_index
 from .metadata import read_csv_with_metadata
 from .metadata import get_valid_csv
+from .metadata import detect_text_encoding
+from .metadigclient import MetaDigClientUtilities
 
 __all__ = [
     "StoreManager",
@@ -34,8 +36,10 @@ __all__ = [
     "find_entity_index",
     "read_csv_with_metadata",
     "get_valid_csv",
+    "detect_text_encoding",
     "run_check",
     "checks",
     "metadata",
     "suites",
+    "MetaDigClientUtilities",
 ]

--- a/metadig/checks.py
+++ b/metadig/checks.py
@@ -115,10 +115,7 @@ def get_data_pids(identifier: str, member_node: str):
         # Send the request and read the response
         with urllib.request.urlopen(req) as response:
             # Read and decode the response
-            data = response.read().decode("utf-8")
-            # Convert the string to bytes so lxml can parse it
-            xml_bytes = data.encode("utf-8")
-            # Iterate over the response to get all the data pids
+            xml_bytes = response.read()
             # pylint: disable=I1101
             root = etree.fromstring(xml_bytes)
 

--- a/metadig/checks.py
+++ b/metadig/checks.py
@@ -179,15 +179,19 @@ def get_sysmeta_vars(sysmeta_path: str):
         rights_holder = sysmeta_doc_root.find("rightsHolder").text
         date_uploaded = sysmeta_doc_root.find("dateUploaded").text
         format_id = sysmeta_doc_root.find("formatId").text
-        obsoletes = sysmeta_doc_root.find("obsoletes").text
         if identifier is None:
             raise ValueError("Element 'identifier' is missing from sysmeta document")
-        if identifier is None:
+        if authoritative_member_node is None:
             raise ValueError("Element 'authoritativeMemberNode' is missing from sysmeta document")
     except AttributeError as ae:
         raise AttributeError(
             "Elements 'identifier' or 'authoritativeMemberNode' is missing from sysmeta document"
         ) from ae
+    
+    try:
+        obsoletes = sysmeta_doc_root.find("obsoletes").text
+    except Exception:
+        obsoletes = None
 
     sm_rn_vars = {}
     sm_rn_vars["identifier"] = identifier

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -175,6 +175,7 @@ def read_csv_with_metadata(d_read, fd, header_line, d_encoding=None):
                     delimiter=fd,
                     header=pd_header_val,
                     encoding=d_encoding,
+                    na_filter=False
                 ),
                 None,
             )

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -36,7 +36,6 @@ def read_sysmeta_element(stream, element):
     except ET.ParseError as e:
         raise ValueError(f"Error parsing XML: {e}, could not find element {element}") from e
 
-
 def find_eml_entity(doc, identifier, file_name):
     """
     Searches through a string EML document to find and return dataTable and otherEntity elements
@@ -76,7 +75,6 @@ def find_eml_entity(doc, identifier, file_name):
 
     # Return None if no match is found
     return None
-
 
 def get_valid_csv(manager, pid):
     """
@@ -191,7 +189,6 @@ def read_csv_with_metadata(d_read, fd, header_line, d_encoding=None):
     except Exception as e:
         return None, f"Error reading CSV: {str(e)}"
 
-
 def find_duplicate_column_names(pandas_df: pandas.DataFrame):
     """Find duplicate columns names in a text delimited file.
 
@@ -218,7 +215,6 @@ def find_duplicate_column_names(pandas_df: pandas.DataFrame):
         checked_cols_names.add(col)
 
     return duplicate_col_names, contains_period
-
 
 def find_duplicate_column_content(pandas_df: pandas.DataFrame):
     """Find duplicate columns in a text delimited file by calculating the hash of the column.
@@ -250,7 +246,6 @@ def find_duplicate_column_content(pandas_df: pandas.DataFrame):
 
     return duplicates
 
-
 def find_duplicate_rows(pandas_df: pandas.DataFrame):
     """Find duplicate rows in a text delimited file.
 
@@ -264,7 +259,6 @@ def find_duplicate_rows(pandas_df: pandas.DataFrame):
         return None
     else:
         return duplicates
-
 
 def find_number_of_columns(pandas_df: pandas.DataFrame):
     """Find the number of columns in a text delimited file.

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -116,6 +116,12 @@ def find_entity_index(fname, pid, entity_names, ids):
         z: Index of matching entity in documentation.
 
     """
+    # Box up single items into a list for interating later
+    if not isinstance(ids, list):
+        ids = [ids]
+    if not isinstance(entity_names, list):
+        entity_names = [entity_names]
+
     # Checks all elements in entity_names to find matches with fname
     z = [i for i, x in enumerate(entity_names) if x == fname]
     # If z is empty, we will try to match by pid instead

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -303,3 +303,18 @@ def detect_text_encoding(raw: bytes):
         confidence = detected_encoding_result.get("confidence")
         encoding_msg = f"Confidence Level: {round(confidence*100, 2)}%"
         return encoding, encoding_msg
+
+
+def escape_for_markdown(string: str):
+    """Parses a string and escapes any of the following special characters
+    so that the string is displayed properly in markdown: \`*_{}[]<>()#+-.!|
+
+    :param string str: String to sanitize
+    :return: A string with special character escaped
+    :rtype: string
+    """
+    markdown_chars_to_escape = set(r"\`*_{}[]<>()#+-.!|")
+    return "".join(
+        f"\\{character}" if character in markdown_chars_to_escape else character
+        for character in string
+    )

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 import io
 import hashlib
 import pandas
+import chardet
 
 
 def read_sysmeta_element(stream, element):
@@ -128,12 +129,13 @@ def find_entity_index(fname, pid, entity_names, ids):
     # If a single match is found, [0] is the value returned
     return z if z else None
 
-def read_csv_with_metadata(d_read, fd, header_line):
+def read_csv_with_metadata(d_read, fd, header_line, d_encoding=None):
     """Uses pandas to read in a csv with given field delimiter and header rows to skip
 
     :param str or bytes d_read: RData as read in from the stream
     :param str fd: ield delimiter from metadata
     :param int header_line: Number of rows to skip
+    :param str d_encoding: Encoding type to use to read the given bytes
 
     :return: A tuple containing:
         - df: Pandas data.frame with data
@@ -168,7 +170,23 @@ def read_csv_with_metadata(d_read, fd, header_line):
         return None, error_msg
 
     try:
-        return pandas.read_csv(io.StringIO(d_read), delimiter=fd, header=pd_header_val), None
+        if d_encoding is not None:
+            return (
+                pandas.read_csv(
+                    io.StringIO(d_read),
+                    delimiter=fd,
+                    header=pd_header_val,
+                    encoding=d_encoding,
+                ),
+                None,
+            )
+        else:
+            return (
+                pandas.read_csv(
+                    io.StringIO(d_read), delimiter=fd, header=pd_header_val
+                ),
+                None,
+            )
     # pylint: disable=W0718
     except Exception as e:
         return None, f"Error reading CSV: {str(e)}"
@@ -283,6 +301,10 @@ def detect_text_encoding(raw: bytes):
         raw.decode("utf-8")
         return "utf-8", None
     except UnicodeDecodeError as e:
+        # If we attempt to decode as utf-8 and run into exceptions, it may contain other
+        # illegal characters. We will attempt to detect the encoding and return the error message.
         err_msg = (
             f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
-        return 'other', err_msg
+        detected_encoding_result = chardet.detect(raw)
+        encoding = detected_encoding_result.get('encoding')
+        return encoding, err_msg

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -256,3 +256,33 @@ def find_number_of_columns(pandas_df: pandas.DataFrame):
     :rtype: int
     """
     return pandas_df.shape[1]
+
+def detect_text_encoding(raw: bytes):
+    """Determine the encoding of the given bytes and return problematic sequences if
+    found. This function first checks for the 'ascii' encoding, before moving onto
+    'utf-8'. If the bytes are neither, we return a tuple that contains 'other' and
+    an error message.
+    
+    :param bytes raw: Raw byte content
+    :return: A tuple containing:
+        - encoding (str): One of 'ascii', 'utf-8', or 'other'
+        - error (str or None): None if decoding succeeded, or a string with error details
+    :rtype: tuple
+    """
+    # First check to see if the raw bytes are encoded as ASCII
+    try:
+        raw.decode("ascii")
+        return "ascii", None
+    # pylint: disable=W0612
+    except UnicodeDecodeError as e:
+        # The bytes are not pure ascii, and it may contain en dashes, accented letters
+        # emojis, etc. so we will check to see if it's utf-8
+        pass
+
+    try:
+        raw.decode("utf-8")
+        return "utf-8", None
+    except UnicodeDecodeError as e:
+        err_msg = (
+            f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
+        return 'other', err_msg

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -297,8 +297,9 @@ def detect_text_encoding(raw: bytes):
     except UnicodeDecodeError as e:
         # If we attempt to decode as utf-8 and run into exceptions, it may contain other
         # illegal characters. We will attempt to detect the encoding and return the error message.
-        err_msg = (
-            f"utf-8 decode error at byte {e.start}: {raw[e.start:e.end]}")
+        # TODO: Detect encoding incrementally: https://chardet.readthedocs.io/en/latest/usage.html
         detected_encoding_result = chardet.detect(raw)
-        encoding = detected_encoding_result.get('encoding')
-        return encoding, err_msg
+        encoding = detected_encoding_result.get("encoding")
+        confidence = detected_encoding_result.get("confidence")
+        encoding_msg = f"Confidence Level: {round(confidence*100, 2)}%"
+        return encoding, encoding_msg

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -6,6 +6,13 @@ import hashlib
 import pandas
 import chardet
 import re
+try:
+    from java.util import ArrayList
+except ImportError:
+    # If there is an issue with importing python recognized java classes from
+    # the Jython environment, we will attempt to create the classes necessary
+    # to proceed with the check.
+    from metadig.checks import ListWithGet as ArrayList
 
 
 def read_sysmeta_element(stream, element):
@@ -117,16 +124,16 @@ def find_entity_index(fname, pid, entity_names, ids):
 
     """
     # Box up single items into a list for interating later
-    if not isinstance(ids, list):
-        ids = [ids]
-    if not isinstance(entity_names, list):
-        entity_names = [entity_names]
+    list_types = (list, ArrayList)
+
+    ids_l = ids if isinstance(ids, list_types) else [ids]
+    entity_names_l = entity_names if isinstance(entity_names, list_types) else [entity_names]
 
     # Checks all elements in entity_names to find matches with fname
-    z = [i for i, x in enumerate(entity_names) if x == fname]
+    z = [i for i, x in enumerate(entity_names_l) if x == fname]
     # If z is empty, we will try to match by pid instead
     if not z:
-        z = [i for i, x in enumerate(ids) if x == pid.replace(":", "-")]
+        z = [i for i, x in enumerate(ids_l) if x == pid.replace(":", "-")]
 
     return z[0] if z else None
 

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -122,11 +122,7 @@ def find_entity_index(fname, pid, entity_names, ids):
     if not z:
         z = [i for i, x in enumerate(ids) if x == pid.replace(":", "-")]
 
-    # If there are multiple matches, we will return the first one
-    if len(z) > 1:
-        z = z[0]
-    # If a single match is found, [0] is the value returned
-    return z if z else None
+    return z[0] if z else None
 
 def read_csv_with_metadata(d_read, fd, header_line, d_encoding=None, nan_filter=False):
     """Uses pandas to read in a csv with given field delimiter and header rows to skip

--- a/metadig/metadata.py
+++ b/metadig/metadata.py
@@ -298,28 +298,26 @@ def detect_text_encoding(raw: bytes):
         - error (str or None): None if decoding succeeded, or a string with error details
     :rtype: tuple
     """
-    # First check to see if the raw bytes are encoded as ASCII
+    # First detect the encoding type
+    detected_encoding_result = chardet.detect(raw)
+    encoding = detected_encoding_result.get("encoding")
+    # Now try to decode it
     try:
-        raw.decode("ascii")
-        return "ascii", None
+        raw.decode(encoding)
+        return encoding, None
     # pylint: disable=W0612
     except UnicodeDecodeError as e:
-        # The bytes are not pure ascii, and it may contain en dashes, accented letters
-        # emojis, etc. so we will check to see if it's utf-8
-        pass
-
-    try:
-        raw.decode("utf-8")
-        return "utf-8", None
-    except UnicodeDecodeError as e:
-        # If we attempt to decode as utf-8 and run into exceptions, it may contain other
-        # illegal characters. We will attempt to detect the encoding and return the error message.
-        # TODO: Detect encoding incrementally: https://chardet.readthedocs.io/en/latest/usage.html
-        detected_encoding_result = chardet.detect(raw)
-        encoding = detected_encoding_result.get("encoding")
+        # If there an a decoding error, return the identified encoding type and the confidence
+        # level, along with details on where we ran into the error.
         confidence = detected_encoding_result.get("confidence")
-        encoding_msg = f"Confidence Level: {round(confidence*100, 2)}%"
+        encoding_msg = (
+            "A decoding error has been detected while attempting to decode the document"
+            + f" with detected encoding: {encoding}. Confidence level of encoding type:"
+            + f" {round(confidence*100, 2)}%. Error Details:"
+            + f" Error at byte {e.start}: {raw[e.start:e.end]}"
+        )
         return encoding, encoding_msg
+
 
 def escape_for_markdown(string: str):
     """Parses a string and escapes any of the following special characters

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 """Metadig Command Line App"""
 import os
+import io
+from typing import Optional
+from pathlib import Path
 from argparse import ArgumentParser
+import urllib.parse
 import yaml
+from lxml import etree
+from hashstore import HashStoreFactory
+from hashstore.filehashstore import HashStoreRefsAlreadyExists
 from metadig import checks
-
 
 class MetaDigPyParser:
     """Class to set up parsing arguments via argparse."""
@@ -28,6 +34,12 @@ class MetaDigPyParser:
             dest="run_check",
             action="store_true",
             help="Flag to run a check through the MetaDIG-py client",
+        )
+        self.parser.add_argument(
+            "-importhashstoredata",
+            dest="import_hashstore_data",
+            action="store_true",
+            help="Flag to run import data to a hashstore using the MetaDIG-py client",
         )
 
         # Arguments to retrieve to run a check
@@ -53,35 +65,54 @@ class MetaDigPyParser:
             "-sysmeta",
             "-sysmeta_doc",
             dest="sysmeta_path",
-            help="Path to document to the sysmeta to retrieve the identifier and member node",
+            help="Path to document to the sysmeta to retrieve the identifier and member node.",
+        )
+        self.parser.add_argument(
+            "-datafolder",
+            "-data_folder",
+            dest="data_folder_path",
+            help="Path to folder containining the desired data objects to upload to hashstore.",
         )
 
     def get_parser_args(self):
         """Get command line arguments."""
         return self.parser.parse_args()
 
-def main():
-    """Entry point of the Metadig client."""
-    # Set-up parser and retrieve arguments
-    parser = MetaDigPyParser()
-    args = parser.get_parser_args()
 
-    run_check = getattr(args, "run_check")
-    store_path = getattr(args, "hashstore_path")
-    check_xml_path = getattr(args, "checkxml_path")
-    metadata_doc_path = getattr(args, "metadatadoc_path")
-    sysmeta_path = getattr(args, "sysmeta_path")
-    if run_check:
-        if store_path is None:
-            raise ValueError("'-store_path' arg is required")
-        if check_xml_path is None:
-            raise ValueError("'-check_xml' arg is required")
-        if metadata_doc_path is None:
-            raise ValueError("'-metadata_doc' arg is required")
-        if sysmeta_path is None:
-            raise ValueError("'-sysmeta_doc' arg is required")
+class MetaDigClientUtilities:
+    """Class to assist the metadig client with running checks and/or suites."""
 
-        # Get the store configuration from the given config file at the store_path
+    def __init__(self):
+        """Initialize the default properties for the MetaDigClientUtilities (ex. hashstore)"""
+        default_hashstore_path = os.getcwd() + "/hashstore"
+        self.default_store_props = self.get_store_manager_props(default_hashstore_path)
+        hashstore_factory = HashStoreFactory()
+        module_name = "hashstore.filehashstore"
+        class_name = "FileHashStore"
+        self.default_store = hashstore_factory.get_hashstore(
+            module_name, class_name, self.default_store_props
+        )
+
+    def get_hashstore_from_factory(self, hashstore_path):
+        """Get a hashstore that is ready to store objects and metadata at the given store path."""
+        self.get_store_manager_props(hashstore_path)
+        hashstore_factory = HashStoreFactory()
+        module_name = "hashstore.filehashstore"
+        class_name = "FileHashStore"
+        hashstore = hashstore_factory.get_hashstore(
+            module_name, class_name, self.default_store_props
+        )
+        return hashstore
+
+    @staticmethod
+    def get_store_manager_props(store_path) -> dict:
+        """Given a path, look for the 'hashstore.yaml' configuration file and return a dictionary
+        that contains the properties found in the config file.
+        
+        :param str path_to_data_folder: Path to the folder containing data objects to store.
+        :return: Dictionary containing store manager properties
+        :rtype: Dict
+        """
         hashstore_yaml_path = store_path + "/hashstore.yaml"
         if not os.path.isfile(hashstore_yaml_path):
             err_msg = "'hashstore.yaml' not found in store root path."
@@ -98,11 +129,195 @@ def main():
                 f"Unexpected exception while trying to read 'hashstore.yaml' from store_path: {ge}"
             ) from ge
 
+        return storemanager_props
+
+    def get_data_object_system_metadata(
+        self, identifier: str, member_node: str, data_folder: str = None
+    ) -> tuple:
+        """Retrieve the system metadata for a data object with the given identifier and
+        member node endpoint
+
+        :param str identifier: The persistent identifier to retrieve data pids for
+        :param str member_node: The member node whose URL to query (ex. 'urn:node:ARCTIC')
+        :param str data_folder: The folder to attempt to try and find the sysmeta file in
+        :return: A tuple containing:
+            - data_obj_file_name (str): File name of the data object.
+            - system_metadata (bytes): Data object's system metadata.
+        :rtype: tuple
+        """
+        data_obj_file_name = None
+        system_metadata = None
+        sysmeta_etree = None
+        # First, try to find the file in the given data folder
+        path_to_sysmeta_file = None
+        if data_folder is not None:
+            sysmeta_to_find = f"sysmeta-{identifier.replace(':','_')}.xml"
+            path_to_sysmeta_file = self.find_file(data_folder, sysmeta_to_find)
+
+        # If a path was found to the system metadata document, read it and set variables
+        if path_to_sysmeta_file is not None:
+            with open(path_to_sysmeta_file, "rb") as f:
+                system_metadata = f.read()
+                # pylint: disable=I1101
+                sysmeta_etree = etree.fromstring(system_metadata)
+        else:
+            # If not, retrieve the system metadata from the DataONE API
+            member_node_url = checks.get_member_node_url(member_node)
+            encoded_identifier = urllib.parse.quote(identifier)
+            sysmeta_query = f"/meta/{encoded_identifier}"
+            query_url = member_node_url + sysmeta_query
+            try:
+                # Create a request and parse response for the associated data pids (objects)
+                req = urllib.request.Request(query_url)
+
+                # Send the request and read the response
+                with urllib.request.urlopen(req) as response:
+                    # Read and decode the response
+                    system_metadata = response.read()
+                    # pylint: disable=I1101
+                    sysmeta_etree = etree.fromstring(system_metadata)
+
+            except Exception as ge:
+                raise RuntimeError(f"Unexpected exception encountered: {ge}") from ge
+
+        for elem in sysmeta_etree.iter():
+            if elem.tag.endswith("fileName"):
+                data_obj_file_name = elem.text
+                break
+
+        return data_obj_file_name, system_metadata
+
+    @staticmethod
+    def find_file(folder_to_check: str, file_to_find: str) -> Path:
+        """Check the supplied folder for the given file and return its full path. This function
+        will also search subfolders.
+
+        :param str folder_to_check: Folder that contains data files
+        :param str file_to_find: The data file to look for
+        :return: Path to the data object
+        :rtype: Path
+        """
+        folder_path = Path(folder_to_check)
+        for path in folder_path.rglob(file_to_find):
+            return path
+        # If nothing is found
+        return None
+
+    def import_data_to_hashstore(
+        self,
+        metadata_sysmeta_path: str,
+        path_to_data_folder: str,
+        hashstore_path: Optional[str] = None,
+    ) -> list:
+        """Takes a dataset metadata sysmeta document and retrieves the associated data pids, and
+        then parses the given path to the data folder to store the data objects into the metadig-py
+        hashstore. The system metadata for each data object is also retrieved and stored.
+
+        :param str metadata_sysmeta_path: Path to the sysmeta for the XML metadata document.
+        :param str path_to_data_folder: Path to the folder containing data objects to store.
+        :param str hashstore_path: Path to a hashstore to store into.
+        :return: The data pids that were stored
+        :rtype: list
+        """
+        # Read the sysmeta
+        sysmeta_vars = checks.get_sysmeta_vars(metadata_sysmeta_path)
+        identifier = sysmeta_vars.get("identifier")
+        auth_mn_node = sysmeta_vars.get("authoritative_member_node")
+        data_pids = checks.get_data_pids(identifier, auth_mn_node)
+
+        if len(data_pids) == 0:
+            raise ValueError(f"No data pids found for identifier: {identifier}")
+        else:
+            # Store the data object and system metadata
+            for pid in data_pids:
+                # Retrieve the system metadata (to be stored) and parse it for the file name
+                data_obj_name, sysmeta = self.get_data_object_system_metadata(
+                    pid, auth_mn_node, path_to_data_folder
+                )
+                data_object_path = self.find_file(path_to_data_folder, data_obj_name)
+                if data_object_path is not None:
+                    # Determine hashstore to use
+                    if hashstore_path is not None:
+                        target_hashstore = self.get_hashstore_from_factory(hashstore_path)
+                    else:
+                        target_hashstore = self.default_store
+                    # Import data to hashstore
+                    try:
+                        target_hashstore.store_object(pid, data_object_path)
+                    except HashStoreRefsAlreadyExists as hsrae:
+                        print(
+                            f"Data object already found in hashstore for pid: {pid}. {hsrae}"
+                        )
+                    # pylint: disable=W0718
+                    except Exception as e:
+                        raise RuntimeError(
+                            f"Unexpected exception while attempting to store data object: {e}"
+                        ) from e
+
+                    try:
+                        sysmeta_file_like_object = io.BytesIO(sysmeta)
+                        sysmeta_file_like_object.name = pid + ".xml"
+                        target_hashstore.store_metadata(
+                            pid, sysmeta_file_like_object
+                        )
+                    # pylint: disable=W0718
+                    except Exception as e:
+                        raise RuntimeError(
+                            f"Unexpected exception while attempting to store data metadata: {e}"
+                        ) from e
+                else:
+                    print(
+                        f"Data object not found: {data_obj_name} in folder: {path_to_data_folder}"
+                    )
+            return data_pids
+
+
+def main():
+    """Entry point of the Metadig client."""
+    # Set-up parser and retrieve arguments
+    mcdu = MetaDigClientUtilities()
+    parser = MetaDigPyParser()
+    args = parser.get_parser_args()
+
+    run_check = getattr(args, "run_check")
+    store_path = getattr(args, "hashstore_path")
+    check_xml_path = getattr(args, "checkxml_path")
+    metadata_doc_path = getattr(args, "metadatadoc_path")
+    sysmeta_path = getattr(args, "sysmeta_path")
+    import_hashstore_data = getattr(args, "import_hashstore_data")
+    data_folder_path = getattr(args, "data_folder_path")
+    if run_check:
+        if store_path is None:
+            raise ValueError("'-store_path' arg is required to run a check")
+        if check_xml_path is None:
+            raise ValueError("'-check_xml' arg is required to run a check")
+        if metadata_doc_path is None:
+            raise ValueError("'-metadata_doc' arg is required to run a check")
+        if sysmeta_path is None:
+            raise ValueError("'-sysmeta_doc' arg is required to run a check")
+
+        # Get the store configuration from the given config file at the store_path
+        storemanager_props = mcdu.get_store_manager_props(store_path)
+
         # Run the check
         result = checks.run_check(
             check_xml_path, metadata_doc_path, sysmeta_path, storemanager_props
         )
         print(result)
+        return
+    if import_hashstore_data:
+        if data_folder_path is None:
+            raise ValueError("'-data_folder' arg is required to import hashstore data")
+        if sysmeta_path is None:
+            raise ValueError("'-sysmeta_doc' arg is required to import hashstore data")
+        # If 'store_path' is None, we will use the default hashstore that ships with metadig-py
+
+        # Parse the sysmeta for the data pids, retrieve the system metadata and store
+        # both the data objects and their respective sysmeta to hashstore
+        data_pids_stored = mcdu.import_data_to_hashstore(
+            sysmeta_path, data_folder_path, store_path
+        )
+        print(f"Data objects have been stored for pids: {data_pids_stored}")
         return
 
 if __name__ == "__main__":

--- a/metadig/metadigclient.py
+++ b/metadig/metadigclient.py
@@ -10,7 +10,7 @@ import yaml
 from lxml import etree
 from hashstore import HashStoreFactory
 from hashstore.filehashstore import HashStoreRefsAlreadyExists
-from metadig import checks
+from metadig import checks, suites
 
 class MetaDigPyParser:
     """Class to set up parsing arguments via argparse."""
@@ -36,6 +36,12 @@ class MetaDigPyParser:
             help="Flag to run a check through the MetaDIG-py client",
         )
         self.parser.add_argument(
+            "-runsuite",
+            dest="run_suite",
+            action="store_true",
+            help="Flag to run a suite through the MetaDIG-py client",
+        )
+        self.parser.add_argument(
             "-importhashstoredata",
             dest="import_hashstore_data",
             action="store_true",
@@ -52,7 +58,7 @@ class MetaDigPyParser:
         self.parser.add_argument(
             "-cxml",
             "-check_xml",
-            dest="checkxml_path",
+            dest="check_xml_path",
             help="Path to the check xml for MetaDIG-py to parse.",
         )
         self.parser.add_argument(
@@ -72,6 +78,18 @@ class MetaDigPyParser:
             "-data_folder",
             dest="data_folder_path",
             help="Path to folder containining the desired data objects to upload to hashstore.",
+        )
+        self.parser.add_argument(
+            "-suitepath",
+            "-suite_path",
+            dest="suite_path",
+            help="Path to suite to run.",
+        )
+        self.parser.add_argument(
+            "-checkfolder",
+            "-check_folder",
+            dest="check_folder_path",
+            help="Path to folder containining the xml checks to execute for a suite.",
         )
 
     def get_parser_args(self):
@@ -280,17 +298,21 @@ def main():
     args = parser.get_parser_args()
 
     run_check = getattr(args, "run_check")
+    run_suite = getattr(args, "run_suite")
     store_path = getattr(args, "hashstore_path")
-    check_xml_path = getattr(args, "checkxml_path")
+    check_xml_path = getattr(args, "check_xml_path")
+    suite_path = getattr(args, "suite_path")
     metadata_doc_path = getattr(args, "metadatadoc_path")
     sysmeta_path = getattr(args, "sysmeta_path")
     import_hashstore_data = getattr(args, "import_hashstore_data")
     data_folder_path = getattr(args, "data_folder_path")
+    check_folder_path = getattr(args, "check_folder_path")
+
     if run_check:
         if store_path is None:
             raise ValueError("'-store_path' arg is required to run a check")
         if check_xml_path is None:
-            raise ValueError("'-check_xml' arg is required to run a check")
+            raise ValueError("'-check_xml_path' arg is required to run a check")
         if metadata_doc_path is None:
             raise ValueError("'-metadata_doc' arg is required to run a check")
         if sysmeta_path is None:
@@ -305,7 +327,32 @@ def main():
         )
         print(result)
         return
-    if import_hashstore_data:
+    elif run_suite:
+        if suite_path is None:
+            raise ValueError("'-suite_path' arg is required to run a suite")
+        if check_folder_path is None:
+            raise ValueError("'-check_folder_path' arg is required to run a suite")
+        if metadata_doc_path is None:
+            raise ValueError("'-metadata_doc' arg is required to run a suite")
+        if sysmeta_path is None:
+            raise ValueError("'-sysmeta_doc' arg is required to run a suite")
+        if store_path is None:
+            raise ValueError("'-store_path' arg is required to run a suite")
+
+        # Get the store configuration from the given config file at the store_path
+        storemanager_props = mcdu.get_store_manager_props(store_path)
+
+        # Run the check
+        suite_results = suites.run_suite(
+            suite_path,
+            check_folder_path,
+            metadata_doc_path,
+            sysmeta_path,
+            storemanager_props,
+        )
+        print(suite_results)
+        return
+    elif import_hashstore_data:
         if data_folder_path is None:
             raise ValueError("'-data_folder' arg is required to import hashstore data")
         if sysmeta_path is None:
@@ -319,6 +366,10 @@ def main():
         )
         print(f"Data objects have been stored for pids: {data_pids_stored}")
         return
+    else:
+        print(
+            "No options provided. Run `metadigpy -h` for more information."
+        )
 
 if __name__ == "__main__":
     main()

--- a/metadig/suites.py
+++ b/metadig/suites.py
@@ -120,10 +120,14 @@ def run_suite(
                     f"Check not found at path: {check_id_path}"
                 )
         else:
+            if check_env is None:
+                output_msg = f"Check not found for: {check_id} in: {checks_path}"
+            else:
+                output_msg = f"Incompatible check environment ({check_env}) for check: {check_id}."
             check_results.append({
                 "check_id": check_id,
                 "identifiers": "N/A",
-                "output": f"Incompatible check environment ({check_env}) for check: {check_id}.",
+                "output": output_msg,
                 "status": "ERROR",
             })
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,99 +48,61 @@ def init_hashstore_with_test_data(store):
     """Store data objects and system metadata for tests to run as expected.'"""
     # Store data and metadata objects for 'object_store' and 'metadata' pytest
     current_dir = os.path.dirname(__file__)
-    obj_path = os.path.join(current_dir, "testdata", "test-data.csv")
-    obj2_path = os.path.join(current_dir, "testdata", "test-data-2.csv")
-    obj3_path = os.path.join(current_dir, "testdata", "test-data-2_3rowstoskip.csv")
-    obj4_path = os.path.join(current_dir, "testdata", "test-data_duplicate_columns.csv")
-    obj5_path = os.path.join(current_dir, "testdata", "test-data_duplicate_columns_dif_names.csv")
-    obj6_path = os.path.join(current_dir, "testdata", "test-data_duplicate_rows.csv")
-    meta_path = os.path.join(current_dir, "testdata", "test-pid.xml")
-    store.store_object("test-pid", str(obj_path))
-    store.store_object("test-pid-2", str(obj2_path))
-    store.store_object("test-pid-3skip", str(obj3_path))
-    store.store_object("test-pid-4dupcols", str(obj4_path))
-    store.store_object("test-pid-dupcols-names", str(obj5_path))
-    store.store_object("test-pid-duprows", str(obj6_path))
-    store.store_metadata("test-pid", str(meta_path))
-    store.store_metadata("test-pid-3skip", str(meta_path))
-    store.store_metadata("test-pid-4dupcols", str(meta_path))
-    store.store_metadata("test-pid-dupcols-names", str(meta_path))
-    store.store_metadata("test-pid-duprows", str(meta_path))
+    testdata_dir = os.path.join(current_dir, "testdata")
+
+    # Store text delimited objects for metadata module checks
+    test_objects = [
+        ("test-pid", "test-data.csv"),
+        ("test-pid-2", "test-data-2.csv"),
+        ("test-pid-3skip", "test-data-2_3rowstoskip.csv"),
+        ("test-pid-4dupcols", "test-data_duplicate_columns.csv"),
+        ("test-pid-dupcols-names", "test-data_duplicate_columns_dif_names.csv"),
+        ("test-pid-duprows", "test-data_duplicate_rows.csv"),
+    ]
+
+    # For ease of adding test data, we are using the same sysmeta which is not tested against
+    meta_path = os.path.join(testdata_dir, "test-pid.xml")
+    for pid, filename in test_objects:
+        store.store_object(pid, os.path.join(testdata_dir, filename))
+        # We are skipping this specific sysmeta to trigger an exception for a pytest
+        if pid != "test-pid-2":
+            store.store_metadata(pid, meta_path)
 
     # Store data and metadata object for 'checks' pytest for DOI: doi:10.18739/A2QJ78081
     doi = "doi:10.18739/A2QJ78081"
-
-    # Store the data object for the eml metadata doc
-    doi_eml_metadata_doc = "doi:10.18739_A2QJ78081.xml"
-    obj_path_to_pid_eml_meta_doc = os.path.join(current_dir, "testdata", doi_eml_metadata_doc)
-    store.store_object(doi, str(obj_path_to_pid_eml_meta_doc))
-
-    # Store the sysmeta for the eml metadata doc
-    doi_eml_metadata_doc = "doi:10.18739_A2QJ78081_sysmeta.xml"
-    obj_path_to_pid_eml_meta_doc_sysmeta = os.path.join(
-        current_dir, "testdata", doi_eml_metadata_doc
+    store.store_object(doi, os.path.join(testdata_dir, "doi:10.18739_A2QJ78081.xml"))
+    store.store_metadata(doi, os.path.join(testdata_dir, "doi:10.18739_A2QJ78081_sysmeta.xml"))
+    # Store associated data objects and sysmeta
+    store.store_object(
+        "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",
+        os.path.join(testdata_dir, "the_arctic_plant_aboveground_biomass_synthesis_dataset.csv")
     )
-    store.store_metadata(doi, str(obj_path_to_pid_eml_meta_doc_sysmeta))
-
-    # Store the associated .CSV
-    pid_associated_file_name = "the_arctic_plant_aboveground_biomass_synthesis_dataset.csv"
-    obj_path_to_pid_obj = os.path.join(current_dir, "testdata", pid_associated_file_name)
-    store.store_object("urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1", str(obj_path_to_pid_obj))
-
-    # Store the sysmeta document for the .CSV
-    pid_sysmeta_name = "urn_uuid_6a7a874a-39b5-4855-85d4-0fdfac795cd1.xml"
-    obj_path_to_pid_sysmeta = os.path.join(current_dir, "testdata", pid_sysmeta_name)
     store.store_metadata(
-        "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1", str(obj_path_to_pid_sysmeta)
+        "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",
+        os.path.join(testdata_dir, "urn_uuid_6a7a874a-39b5-4855-85d4-0fdfac795cd1.xml")
     )
 
     # Store data and metadata object for 'checks' pytest for DOI: doi:10.18739/A2RJ48X0F
-    # We will physically alter the data to have normalization issues
+    # We have physically altered the data to have normalization issues
     nmi_doi = "doi:10.18739/A2RJ48X0F"
-
-    # Store the data object for the eml metadata doc
-    nmi_doi_eml_metadata_doc = "doi:10.18739_A2RJ48X0F.xml"
-    nmi_obj_path_to_pid_eml_meta_doc = os.path.join(
-        current_dir, "testdata", nmi_doi_eml_metadata_doc
+    store.store_object(nmi_doi, os.path.join(testdata_dir, "doi:10.18739_A2RJ48X0F.xml"))
+    store.store_metadata(nmi_doi, os.path.join(testdata_dir, "doi:10.18739_A2QJ78081_sysmeta.xml"))
+    # Store associated data objects and sysmeta
+    store.store_object(
+        "urn:uuid:a4aadc85-9fa4-46c9-9642-46066cf7a691",
+        os.path.join(testdata_dir, "SKQ2020309T_Chla_modified.csv")
     )
-    store.store_object(nmi_doi, str(nmi_obj_path_to_pid_eml_meta_doc))
-
-    # Store the sysmeta for the eml metadata doc
-    nmi_doi_eml_metadata_doc = "doi:10.18739_A2QJ78081_sysmeta.xml"
-    nmi_obj_path_to_pid_eml_meta_doc_sysmeta = os.path.join(
-        current_dir, "testdata", nmi_doi_eml_metadata_doc
-    )
-    store.store_metadata(nmi_doi, str(nmi_obj_path_to_pid_eml_meta_doc_sysmeta))
-
-    # Store the associated .CSV
-    nmi_pid_associated_file_name = "SKQ2020309T_Chla_modified.csv"
-    nmi_obj_path_to_pid_obj = os.path.join(
-        current_dir, "testdata", nmi_pid_associated_file_name
+    store.store_metadata(
+        "urn:uuid:a4aadc85-9fa4-46c9-9642-46066cf7a691",
+        os.path.join(testdata_dir, "urn_uuid_a4aadc85-9fa4-46c9-9642-46066cf7a691.xml")
     )
     store.store_object(
-        "urn:uuid:a4aadc85-9fa4-46c9-9642-46066cf7a691", str(nmi_obj_path_to_pid_obj)
+        "urn:uuid:60101459-96a2-41ea-b9e7-0dd80ecde3ce",
+        os.path.join(testdata_dir, "SKQ2020309T_Chlorophyll_Pigments_README.pdf")
     )
-
-    # Store the sysmeta document for the .CSV
-    nmi_pid_sysmeta_name = "urn_uuid_a4aadc85-9fa4-46c9-9642-46066cf7a691.xml"
-    nmi_obj_path_to_pid_sysmeta = os.path.join(current_dir, "testdata", nmi_pid_sysmeta_name)
     store.store_metadata(
-        "urn:uuid:a4aadc85-9fa4-46c9-9642-46066cf7a691", str(nmi_obj_path_to_pid_sysmeta)
-    )
-
-    # Store other related files to the dataset (must be present in hashstore)
-    other_pid_associated_file_name = "SKQ2020309T_Chlorophyll_Pigments_README.pdf"
-    other_obj_path_to_pid_obj = os.path.join(
-        current_dir, "testdata", other_pid_associated_file_name
-    )
-    store.store_object(
-        "urn:uuid:60101459-96a2-41ea-b9e7-0dd80ecde3ce", str(other_obj_path_to_pid_obj)
-    )
-
-    other_pid_sysmeta_name = "urn_uuid_60101459-96a2-41ea-b9e7-0dd80ecde3ce.xml"
-    other_obj_path_to_pid_sysmeta = os.path.join(current_dir, "testdata", other_pid_sysmeta_name)
-    store.store_metadata(
-        "urn:uuid:60101459-96a2-41ea-b9e7-0dd80ecde3ce", str(other_obj_path_to_pid_sysmeta)
+        "urn:uuid:60101459-96a2-41ea-b9e7-0dd80ecde3ce",
+        os.path.join(testdata_dir, "urn_uuid_60101459-96a2-41ea-b9e7-0dd80ecde3ce.xml")
     )
 
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def init_hashstore_with_test_data(store):
         ("test-pid-4dupcols", "test-data_duplicate_columns.csv"),
         ("test-pid-dupcols-names", "test-data_duplicate_columns_dif_names.csv"),
         ("test-pid-duprows", "test-data_duplicate_rows.csv"),
+        ("test-pid-decode-errors", "test-data_illegalcharacter.csv"),
     ]
 
     # For ease of adding test data, we are using the same sysmeta which is not tested against

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@
 import os
 import pytest
 from hashstore import HashStoreFactory
+from metadig import MetaDigClientUtilities
+
+@pytest.fixture(name="mcdu")
+def init_metadig_client_utilities():
+    """Create and return the path to a hashstore"""
+    return MetaDigClientUtilities()
+
 
 @pytest.fixture(name="store_path")
 def init_store_path(tmp_path):
@@ -58,7 +65,7 @@ def init_hashstore_with_test_data(store):
         ("test-pid-4dupcols", "test-data_duplicate_columns.csv"),
         ("test-pid-dupcols-names", "test-data_duplicate_columns_dif_names.csv"),
         ("test-pid-duprows", "test-data_duplicate_rows.csv"),
-        ("test-pid-decode-errors", "test-data_illegalcharacter.csv"),
+        ("test-pid-utf-8-decode-errors", "test-data_illegalcharacter.csv"),
     ]
 
     # For ease of adding test data, we are using the same sysmeta which is not tested against
@@ -76,7 +83,10 @@ def init_hashstore_with_test_data(store):
     # Store associated data objects and sysmeta
     store.store_object(
         "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",
-        os.path.join(testdata_dir, "the_arctic_plant_aboveground_biomass_synthesis_dataset.csv")
+        os.path.join(
+            testdata_dir,
+            "the_arctic_plant_aboveground_biomass_synthesis_dataset_v1_2.csv",
+        ),
     )
     store.store_metadata(
         "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,17 +46,26 @@ def init_hashstore(hashstore_props):
 @pytest.fixture
 def init_hashstore_with_test_data(store):
     """Store data objects and system metadata for tests to run as expected.'"""
-    # Store data and metadata objects for 'object_store' pytest
+    # Store data and metadata objects for 'object_store' and 'metadata' pytest
     current_dir = os.path.dirname(__file__)
     obj_path = os.path.join(current_dir, "testdata", "test-data.csv")
     obj2_path = os.path.join(current_dir, "testdata", "test-data-2.csv")
     obj3_path = os.path.join(current_dir, "testdata", "test-data-2_3rowstoskip.csv")
+    obj4_path = os.path.join(current_dir, "testdata", "test-data_duplicate_columns.csv")
+    obj5_path = os.path.join(current_dir, "testdata", "test-data_duplicate_columns_dif_names.csv")
+    obj6_path = os.path.join(current_dir, "testdata", "test-data_duplicate_rows.csv")
     meta_path = os.path.join(current_dir, "testdata", "test-pid.xml")
     store.store_object("test-pid", str(obj_path))
     store.store_object("test-pid-2", str(obj2_path))
     store.store_object("test-pid-3skip", str(obj3_path))
+    store.store_object("test-pid-4dupcols", str(obj4_path))
+    store.store_object("test-pid-dupcols-names", str(obj5_path))
+    store.store_object("test-pid-duprows", str(obj6_path))
     store.store_metadata("test-pid", str(meta_path))
     store.store_metadata("test-pid-3skip", str(meta_path))
+    store.store_metadata("test-pid-4dupcols", str(meta_path))
+    store.store_metadata("test-pid-dupcols-names", str(meta_path))
+    store.store_metadata("test-pid-duprows", str(meta_path))
 
     # Store data and metadata object for 'checks' pytest for DOI: doi:10.18739/A2QJ78081
     doi = "doi:10.18739/A2QJ78081"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -103,6 +103,35 @@ def test_run_check_datatable_normalized(storemanager_props, init_hashstore_with_
     assert result_data["status"] == "FAILURE"
 
 
+def test_run_check_data_character_encoding(storemanager_props, init_hashstore_with_test_data):
+    """Test 'run_check' with 'data.table-text-delimited.normalized.xml' python check."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+    # Confirm no exception is thrown and object and metadata is in place
+    _ = manager.get_object("urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1")
+
+    # Now execute 'run_check' by providing it the required args
+    sample_check_file_path = get_test_data_path(
+        "checks/data.character-encoding.xml"
+    )
+    sample_metadata_file_path = get_test_data_path("doi:10.18739_A2QJ78081.xml")
+    sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
+
+    result = checks.run_check(
+        sample_check_file_path,
+        sample_metadata_file_path,
+        sample_sysmeta_file_path,
+        storemanager_props,
+    )
+
+    result_data = json.loads(result)
+    assert result_data is not None
+    assert result_data["identifiers"] is not None
+    assert result_data["output"] is not None
+    assert "does not contain encoding errors" in result_data["output"][0]
+    assert result_data["status"] == "SUCCESS"
+
+
 def test_try_run_check_with_multiprocessing(storemanager_props, init_hashstore_with_test_data):
     """Test 'run_check' function in a multiprocessing setting"""
     assert init_hashstore_with_test_data

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -112,7 +112,7 @@ def test_run_check_data_character_encoding(storemanager_props, init_hashstore_wi
 
     # Now execute 'run_check' by providing it the required args
     sample_check_file_path = get_test_data_path(
-        "checks/data.character-encoding.xml"
+        "checks/data.text-encoding.valid.xml"
     )
     sample_metadata_file_path = get_test_data_path("doi:10.18739_A2QJ78081.xml")
     sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -69,8 +69,38 @@ def test_run_check_datatable_variables_congruent(storemanager_props, init_hashst
     assert result_data is not None
     assert result_data["identifiers"] is not None
     assert result_data["output"] is not None
-    assert "variable names match documentation." in result_data["output"][0]
+    assert "variable names do not match documentation." in result_data["output"][0]
     assert result_data["status"] is not None
+
+
+def test_run_check_datatable_normalized(storemanager_props, init_hashstore_with_test_data):
+    """Test 'run_check' with 'data.table-text-delimited.normalized.xml' python check."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+    # Confirm no exception is thrown and object and metadata is in place
+    _ = manager.get_object("urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1")
+
+    # Now execute 'run_check' by providing it the required args
+    sample_check_file_path = get_test_data_path(
+        "checks/data.table-text-delimited.normalized.xml"
+    )
+    sample_metadata_file_path = get_test_data_path("doi:10.18739_A2QJ78081.xml")
+    sample_sysmeta_file_path = get_test_data_path("doi:10.18739_A2QJ78081_sysmeta.xml")
+
+    result = checks.run_check(
+        sample_check_file_path,
+        sample_metadata_file_path,
+        sample_sysmeta_file_path,
+        storemanager_props,
+    )
+
+    result_data = json.loads(result)
+    # print(result_data)
+    assert result_data is not None
+    assert result_data["identifiers"] is not None
+    assert result_data["output"] is not None
+    assert "contains normalization issues" in result_data["output"][0]
+    assert result_data["status"] == "FAILURE"
 
 
 def test_try_run_check_with_multiprocessing(storemanager_props, init_hashstore_with_test_data):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -326,10 +326,10 @@ def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test
     """Confirm that 'detect_text_encoding' reads the bytes as expected."""
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
-    pid = "test-pid-decode-errors"
+    pid = "test-pid-utf-8-decode-errors"
     obj, _ = manager.get_object(pid)
     bytes_read = obj.read()
 
     enc_type, msg = metadata.detect_text_encoding(bytes_read)
-    assert enc_type == "other"
+    assert enc_type == "ISO-8859-1"
     assert "decode error at" in msg

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -318,7 +318,7 @@ def test_detect_text_encoding_utf8(storemanager_props, init_hashstore_with_test_
     bytes_read = obj.read()
 
     enc_type, msg = metadata.detect_text_encoding(bytes_read)
-    assert enc_type == "utf-8"
+    assert enc_type == "Windows-1252"
     assert msg is None
 
 
@@ -332,8 +332,7 @@ def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test
 
     enc_type, msg = metadata.detect_text_encoding(bytes_read)
     assert enc_type == "ISO-8859-1"
-    print(msg)
-    assert "Confidence Level" in msg
+    assert msg is None
 
 
 def test_escape_for_markdown():
@@ -341,6 +340,7 @@ def test_escape_for_markdown():
     string_to_escape = "American_Black_Duck_x_Mallard_.hybrid."
     escaped_string = metadata.escape_for_markdown(string_to_escape)
     assert escaped_string == r"American\_Black\_Duck\_x\_Mallard\_\.hybrid\."
+
 
 def test_find_entity_index_fname():
     fname = "data.csv"
@@ -351,6 +351,7 @@ def test_find_entity_index_fname():
     result = metadata.find_entity_index(fname, pid, entity_names, ids)
     assert result == 1
 
+
 def test_find_entity_index_single_pid():
     fname = "data.csv"
     pid = "urn:uuid:1234"
@@ -359,6 +360,7 @@ def test_find_entity_index_single_pid():
 
     result = metadata.find_entity_index(fname, pid, entity_names, ids)
     assert result == 0
+
 
 def test_find_entity_index_multi_pid():
     fname = "data.csv"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -293,3 +293,43 @@ def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_dat
     df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
     num_of_cols = metadata.find_number_of_columns(df)
     assert num_of_cols == 9
+
+
+def test_detect_text_encoding_ascii(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'detect_text_encoding' reads the bytes as ascii."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "test-pid"
+    obj, _ = manager.get_object(pid)
+    bytes_read = obj.read()
+
+    enc_type, msg = metadata.detect_text_encoding(bytes_read)
+    assert enc_type == "ascii"
+    assert msg is None
+
+
+def test_detect_text_encoding_utf8(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'detect_text_encoding' reads the bytes as expected."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+    pid = "test-pid-3skip"
+    obj, _ = manager.get_object(pid)
+    bytes_read = obj.read()
+
+    enc_type, msg = metadata.detect_text_encoding(bytes_read)
+    assert enc_type == "utf-8"
+    assert msg is None
+
+
+def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'detect_text_encoding' reads the bytes as expected."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+    pid = "test-pid-decode-errors"
+    obj, _ = manager.get_object(pid)
+    bytes_read = obj.read()
+
+    enc_type, msg = metadata.detect_text_encoding(bytes_read)
+    assert enc_type == "other"
+    assert "decode error at" in msg

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -334,3 +334,10 @@ def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test
     assert enc_type == "ISO-8859-1"
     print(msg)
     assert "Confidence Level" in msg
+
+
+def test_escape_for_markdown():
+    """Confirm that special characters are escaped"""
+    string_to_escape = "American_Black_Duck_x_Mallard_.hybrid."
+    escaped_string = metadata.escape_for_markdown(string_to_escape)
+    assert escaped_string == r"American\_Black\_Duck\_x\_Mallard\_\.hybrid\."

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -341,3 +341,30 @@ def test_escape_for_markdown():
     string_to_escape = "American_Black_Duck_x_Mallard_.hybrid."
     escaped_string = metadata.escape_for_markdown(string_to_escape)
     assert escaped_string == r"American\_Black\_Duck\_x\_Mallard\_\.hybrid\."
+
+def test_find_entity_index_fname():
+    fname = "data.csv"
+    pid = "urn:uuid:1234"
+    entity_names = ["other.csv", "data.csv", "final.csv"]
+    ids = ["urn-uuid-9999", "urn-uuid-1234", "urn-uuid-8888"]
+
+    result = metadata.find_entity_index(fname, pid, entity_names, ids)
+    assert result == 1
+
+def test_find_entity_index_single_pid():
+    fname = "data.csv"
+    pid = "urn:uuid:1234"
+    entity_names = ["other.csv" "final.csv"]
+    ids = "urn-uuid-1234"
+
+    result = metadata.find_entity_index(fname, pid, entity_names, ids)
+    assert result == 0
+
+def test_find_entity_index_multi_pid():
+    fname = "data.csv"
+    pid = "urn:uuid:5678"
+    entity_names = ["other.csv" "final.csv"]
+    ids = ["urn-uuid-1234", "urn-uuid-5678"]
+
+    result = metadata.find_entity_index(fname, pid, entity_names, ids)
+    assert result == 1

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -332,4 +332,5 @@ def test_detect_text_encoding_other(storemanager_props, init_hashstore_with_test
 
     enc_type, msg = metadata.detect_text_encoding(bytes_read)
     assert enc_type == "ISO-8859-1"
-    assert "decode error at" in msg
+    print(msg)
+    assert "Confidence Level" in msg

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -168,3 +168,130 @@ def test_read_csv_with_metadata_3_rows_to_skip(
         list(df.columns) == expected_columns
     ), f"Unexpected column names: {list(df.columns)}"
     assert error is None
+
+
+def test_find_duplicate_column_content_none(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_column_content' returns an empty list when there
+    are no duplicate column content."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
+    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupes = metadata.find_duplicate_column_content(df)
+    assert len(dupes) == 0
+
+
+def test_find_duplicate_column_content_found(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_column_content' returns returns a list of tuples when
+    duplicate columns are found."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "test-pid-dupcols-names"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupes = metadata.find_duplicate_column_content(df)
+    assert len(dupes) == 2
+
+
+def test_find_duplicate_column_names_none(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_column_name' returns an empty list when there
+    are no duplicate column names."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
+    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupes_col_names, _ = metadata.find_duplicate_column_names(df)
+    assert len(dupes_col_names) == 0
+
+
+def test_find_duplicate_column_names_found(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_column_name' returns a list of tuples when duplicate
+    column names are found."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "test-pid-4dupcols"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupes_col_names, contains_period = metadata.find_duplicate_column_names(df)
+    assert len(dupes_col_names) == 2
+    assert contains_period
+
+
+def test_find_duplicate_rows_none(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_rows' returns None when no duplicate rows are found."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupe_rows_found = metadata.find_duplicate_rows(df)
+    assert dupe_rows_found is None
+
+
+def test_find_duplicate_rows_found(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_duplicate_rows' does not return None when no duplicate rows
+    are found."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "test-pid-duprows"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    dupe_rows_found = metadata.find_duplicate_rows(df)
+    assert dupe_rows_found is not None
+
+
+def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_data):
+    """Confirm that 'find_number_of_columns' counts columns successfully."""
+    assert init_hashstore_with_test_data
+    manager = StoreManager(storemanager_props)
+
+    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    obj, _ = manager.get_object(pid)
+
+    d_read = obj.read().decode('utf-8', errors = 'replace')
+    field_delimiter = ","
+    skiprows = 0
+
+    df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
+    num_of_cols = metadata.find_number_of_columns(df)
+    assert num_of_cols == 33

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -176,8 +176,7 @@ def test_find_duplicate_column_content_none(storemanager_props, init_hashstore_w
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -213,8 +212,7 @@ def test_find_duplicate_column_names_none(storemanager_props, init_hashstore_wit
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    # the_arctic_plant_aboveground_biomass_synthesis_dataset.csv
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -250,7 +248,7 @@ def test_find_duplicate_rows_none(storemanager_props, init_hashstore_with_test_d
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -285,7 +283,7 @@ def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_dat
     assert init_hashstore_with_test_data
     manager = StoreManager(storemanager_props)
 
-    pid = "urn:uuid:6a7a874a-39b5-4855-85d4-0fdfac795cd1"
+    pid = "test-pid"
     obj, _ = manager.get_object(pid)
 
     d_read = obj.read().decode('utf-8', errors = 'replace')
@@ -294,4 +292,4 @@ def test_find_number_of_columns(storemanager_props, init_hashstore_with_test_dat
 
     df, _ = metadata.read_csv_with_metadata(d_read, field_delimiter, skiprows)
     num_of_cols = metadata.find_number_of_columns(df)
-    assert num_of_cols == 33
+    assert num_of_cols == 9

--- a/tests/test_metadigclient.py
+++ b/tests/test_metadigclient.py
@@ -53,16 +53,16 @@ def test_metadig_client_run_check_missing_args(missing_opt, store):
     """Use pytest 'parametrize' decorator to efficiently test missing arguments"""
     client_directory = os.getcwd() + "/metadig"
     client_module_path = f"{client_directory}/metadigclient.py"
-    test_dir = "tests/testdata/"
+    test_dir = "tests/testdata"
     test_store_path = str(store.root)
     run_check_opt = "-runcheck"
 
     # Map options
     options = {
         "store_path": f"-store_path={test_store_path}",
-        "check_xml": f"-check_xml={test_dir}/data.table-text-delimited.glimpse.xml",
-        "metadata_doc": f"-metadata_doc={test_dir}/doi:10.18739_A2QJ78081.xml",
-        "sysmeta_doc": f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml",
+        "check_xml": f"-check_xml={test_dir}data.table-text-delimited.glimpse.xml",
+        "metadata_doc": f"-metadata_doc={test_dir}doi:10.18739_A2QJ78081.xml",
+        "sysmeta_doc": f"-sysmeta_doc={test_dir}doi:10.18739_A2QJ78081_sysmeta.xml",
     }
 
     # Remove the missing option dynamically by creating a new list that excludes the missing opt
@@ -85,7 +85,7 @@ def test_metadig_client_import_data_to_hashstore(capsys):
     """Confirm that the metadig client imports data to hashstore successfully."""
     client_directory = os.getcwd() + "/metadig"
     client_module_path = f"{client_directory}/metadigclient.py"
-    test_dir = "tests/testdata/"
+    test_dir = "tests/testdata"
     import_hashstore_opt = "-importhashstoredata"
     sysmeta_doc_path_opt = f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml"
     data_folder_opt = f"-data_folder={test_dir}"
@@ -104,6 +104,41 @@ def test_metadig_client_import_data_to_hashstore(capsys):
     result_data = capsys.readouterr().out
     assert "Data objects have been stored for pids" in result_data
 
+
+def test_metadig_client_run_suite(capsys, store, init_hashstore_with_test_data):
+    """Confirm metadig runs a check successfully"""
+    assert init_hashstore_with_test_data
+    client_directory = os.getcwd() + "/metadig"
+    client_module_path = f"{client_directory}/metadigclient.py"
+    test_dir = "tests/testdata"
+    test_store_path = str(store.root)
+    run_check_opt = "-runsuite"
+    hashstore_path_opt = f"-store_path={test_store_path}"
+    suite_path_opt = f"-suite_path={test_dir}/data-suite.xml"
+    check_folder_path_opt = f"-check_folder={test_dir}/checks/"
+    metadata_doc_path_opt = f"-metadata_doc={test_dir}/doi:10.18739_A2QJ78081.xml"
+    sysmeta_doc_path_opt = f"-sysmeta_doc={test_dir}/doi:10.18739_A2QJ78081_sysmeta.xml"
+
+    chs_args = [
+        client_module_path,
+        run_check_opt,
+        hashstore_path_opt,
+        suite_path_opt,
+        check_folder_path_opt,
+        metadata_doc_path_opt,
+        sysmeta_doc_path_opt
+    ]
+
+    sys.path.append(client_directory)
+    sys.argv = chs_args
+    metadigclient.main()
+
+    result_data = json.loads(capsys.readouterr().out)
+    assert result_data is not None
+    assert result_data["suite"] == "data-suite.xml"
+    assert result_data["sysmeta"] is not None
+    assert result_data["run_status"] == "SUCCESS"
+    assert result_data["results"] is not None
 
 # MetaDigClientUtilities Tests
 

--- a/tests/testdata/checks/data.character-encoding.xml
+++ b/tests/testdata/checks/data.character-encoding.xml
@@ -17,9 +17,8 @@ def call():
     global output_type
     global metadigpy_result
 
-    from metadig import metadata
+    from metadig import metadata as md
     from metadig import StoreManager
-    import metadig as md
 
     manager = StoreManager(storeConfiguration)  
 
@@ -38,7 +37,7 @@ def call():
         # If data object is not available, skip the pid.
         try:
           obj, sys = manager.get_object(pid)
-          fname = metadata.read_sysmeta_element(sys, "fileName")
+          fname = md.read_sysmeta_element(sys, "fileName")
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
@@ -47,7 +46,7 @@ def call():
 
         # Check character encoding
         bytes_read = obj.read()
-        enc_type, msg = metadata.detect_text_encoding(bytes_read)
+        enc_type, msg = md.detect_text_encoding(bytes_read)
         # TODO: Discuss whether we should also look for characters that can cause
         #       parsing concerns like \n, \t and add a warning
         if enc_type == "ascii":

--- a/tests/testdata/checks/data.character-encoding.xml
+++ b/tests/testdata/checks/data.character-encoding.xml
@@ -58,8 +58,10 @@ def call():
             output_data.append(f"{fname} is a valid 'utf-8' document and does not contain encoding errors.")
             output_type.append("text")
             status_data.append("SUCCESS")
-        elif enc_type == "other":
-            output_data.append(f"Cannot determine type of {fname}. Additional details: {msg}.")
+        else:
+            # TODO: For now, we will only accept valid 'utf-8' and 'ascii' documents as a SUCCESS
+            #       Discuss if we should have specific standards, or should proceed in another path
+            output_data.append(f"{fname} has been detected as a '{enc_type}' document, and may contain errors: {msg}.")
             output_type.append("text")
             status_data.append("FAILURE")
 

--- a/tests/testdata/checks/data.character-encoding.xml
+++ b/tests/testdata/checks/data.character-encoding.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdq:check xmlns:mdq="https://nceas.ucsb.edu/mdqe/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://nceas.ucsb.edu/mdqe/v1 ../schemas/schema1.xsd">
+  <id>data.character-encoding</id>
+  <name>Text data characters are encoded correctly</name>
+  <description>Check that the text content is decodable and whether it's ascii or utf-8.</description>
+  <type>identification</type>
+  <level>INFO</level>
+  <environment>python</environment>
+  <code><![CDATA[
+
+def call():
+    global output
+    global status
+    global output_identifiers
+    global output_type
+    global metadigpy_result
+
+    from metadig import metadata
+    from metadig import StoreManager
+    import metadig as md
+
+    manager = StoreManager(storeConfiguration)  
+
+    output_data = []
+    status_data = []
+    output_identifiers = []
+    output_type = []
+    metadigpy_result = {}
+
+    if len(dataPids) == 0:
+      output_data = "No data objects found."
+
+    for pid in dataPids:
+        output_identifiers.append(pid)
+
+        # If data object is not available, skip the pid.
+        try:
+          obj, sys = manager.get_object(pid)
+          fname = metadata.read_sysmeta_element(sys, "fileName")
+        except Exception as e:
+            output_data.append(f"Unexpected Exception: {e}")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+
+        # Check character encoding
+        bytes_read = obj.read()
+        enc_type, msg = metadata.detect_text_encoding(bytes_read)
+        # TODO: Discuss whether we should also look for characters that can cause
+        #       parsing concerns like \n, \t and add a warning
+        if enc_type == "ascii":
+            output_data.append(f"{fname} is a valid 'ascii' document and does not contain encoding errors.")
+            output_type.append("text")
+            status_data.append("SUCCESS")
+        elif enc_type == "utf-8":
+            output_data.append(f"{fname} is a valid 'utf-8' document and does not contain encoding errors.")
+            output_type.append("text")
+            status_data.append("SUCCESS")
+        elif enc_type == "other":
+            output_data.append(f"Cannot determine type of {fname}. Additional details: {msg}.")
+            output_type.append("text")
+            status_data.append("FAILURE")
+
+    successes = sum(x == "SUCCESS" for x in status_data)
+    failures = sum(x == "FAILURE" for x in status_data)
+    skips = sum(x == "SKIP" for x in status_data)
+    output = output_data
+    if successes > 0 and failures == 0:
+        status = "SUCCESS"
+    elif successes == 0 and failures > 0:
+        status = "FAILURE"
+    else:
+        status = "FAILURE"
+
+    metadigpy_result["identifiers"] = output_identifiers
+    metadigpy_result["output"] = output_data
+    metadigpy_result["status"] = status
+    return True
+
+  ]]></code>
+  <selector>
+    <name>entityNames</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+    <subSelector>
+      <name>...</name>
+      <xpath>./entityName</xpath>
+    </subSelector>
+  </selector>
+  <dialect>
+    <name>Ecological Metadata Language</name>
+    <xpath>boolean(/*[local-name() = 'eml'])</xpath>
+  </dialect>
+</mdq:check>

--- a/tests/testdata/checks/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/checks/data.table-text-delimited.normalized.xml
@@ -18,8 +18,7 @@ def call():
     global metadigpy_result
 
     from metadig import StoreManager
-    from metadig import metadata
-    import metadig as md
+    from metadig import metadata as md
     import pandas as pd
     import io
 
@@ -53,33 +52,32 @@ def call():
             status_data.append("FAILURE")
             continue
 
-        # read in all the data
-        d_read = obj.read().decode('utf-8', errors = 'replace')
-
-        # find which entity file is documented in
-        index_list = md.find_entity_index(fname, pid, entityNames, ids)
-        if index_list is None:
+        # Ensure that the data object is documented in the list of entity names
+        entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
+        if entity_index is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        # Set entity index number to the first item in the list
-        z = index_list[0]
 
-        # Set default value using the entity index
-        num_header_lines = z
+        # Set the default expecated header line value (the first row is headers)
+        num_header_lines = 0
         # headerLines represents 'numHeaderLines' which is retrieved from the EML document
         if isinstance(headerLines, list):
             # If we successfully retrieve a list, we will check what the value is
-            if headerLines[z] == 'null':
+            header_line_value = headerLines[entity_index]
+            if header_line_value == 'null':
                 # There are no header lines
-                num_header_lines = 0
-            if isinstance(headerLines[z], int):
+                pass
+            if isinstance(header_line_value, int):
                 # We'll use the value from the list of it is an integer
-                num_header_lines = headerLines[z]
+                num_header_lines = header_line_value
         
-        # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
+        # Try to read the data object
+        obj_bytes_read = obj.read()
+        encoding_type, enc_msg = md.detect_text_encoding(obj_bytes_read)
+        d_read_decoded = obj_bytes_read.decode(encoding_type)
+        df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
             output_data.append(f"{fname} is unable to be read as a table. {error}")
             output_type.append("text")
@@ -91,7 +89,7 @@ def call():
         normalization_errors_data = []
 
         # Check for duplicate field names
-        duplicate_cols, contains_period = metadata.find_duplicate_column_names(df)
+        duplicate_cols, contains_period = md.find_duplicate_column_names(df)
         if duplicate_cols:
             normalization_errors_count += 1
             normalization_errors_data.append(f"{fname} contains duplicate columns: {', '.join(duplicate_cols)}")
@@ -101,7 +99,7 @@ def call():
             normalization_errors_data.append(warn_msg)
 
         # Check for duplicate column content
-        duplicate_col_content = metadata.find_duplicate_column_content(df)
+        duplicate_col_content = md.find_duplicate_column_content(df)
         if len(duplicate_col_content) != 0:
             normalization_errors_count += 1
             error_msg = "; ".join(
@@ -113,7 +111,7 @@ def call():
             )
 
         # Check for duplicate rows
-        duplicate_rows = metadata.find_duplicate_rows(df)
+        duplicate_rows = md.find_duplicate_rows(df)
         if duplicate_rows is not None:
             dr_summary = duplicate_rows.to_markdown()
             normalization_errors_count += 1
@@ -122,7 +120,7 @@ def call():
             )
 
         # Check for obscene amount of columns
-        num_of_cols = metadata.find_number_of_columns(df)
+        num_of_cols = md.find_number_of_columns(df)
         if num_of_cols >= 1000:
             normalization_errors_count += 1
             normalization_errors_data.append(

--- a/tests/testdata/checks/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/checks/data.table-text-delimited.normalized.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdq:check xmlns:mdq="https://nceas.ucsb.edu/mdqe/v1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://nceas.ucsb.edu/mdqe/v1 ../schemas/schema1.xsd">
+  <id>data.table-text-delimited.normalized</id>
+  <name>Check whether the data is normalized.</name>
+  <description>Data is normalized when there are no duplicate columns or rows and does not contain duplicate column or row names </description>
+  <type>identification</type>
+  <level>INFO</level>
+  <environment>python</environment>
+  <code><![CDATA[
+
+def call():
+    global output
+    global status
+    global output_identifiers
+    global output_type
+    global metadigpy_result
+
+    from metadig import StoreManager
+    from metadig import metadata
+    import metadig as md
+    import pandas as pd
+    import io
+
+    manager = StoreManager(storeConfiguration)  
+
+    output_data = []
+    status_data = []
+    output_identifiers = []
+    output_type = []
+    metadigpy_result = {}
+
+    if len(dataPids) == 0:
+      output_data = "No data objects found."
+
+    for pid in dataPids:
+        output_identifiers.append(pid)
+
+        # If data object is not available, skip the pid.
+        try:
+          # if file is not text/csv, skip it
+          # otherwise get the object and filename
+          obj, fname, csv_status = md.get_valid_csv(manager, pid)
+          if csv_status == "SKIP":
+              output_data.append(f"{fname} is not a text-delimited table, skipping.")
+              output_type.append("text")
+              status_data.append(csv_status)
+              continue
+        except Exception as e:
+            output_data.append(f"Unexpected Exception: {e}")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+
+        # read in all the data
+        d_read = obj.read().decode('utf-8', errors = 'replace')
+
+        # find which entity file is documented in
+        index_list = md.find_entity_index(fname, pid, entityNames, ids)
+        if index_list is None:
+            output_data.append(f"{fname} does not appear to be documented in the metadata.")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+        # Set entity index number to the first item in the list
+        z = index_list[0]
+
+        # Set default value using the entity index
+        num_header_lines = z
+        # headerLines represents 'numHeaderLines' which is retrieved from the EML document
+        if isinstance(headerLines, list):
+            # If we successfully retrieve a list, we will check what the value is
+            if headerLines[z] == 'null':
+                # There are no header lines
+                num_header_lines = 0
+            if isinstance(headerLines[z], int):
+                # We'll use the value from the list of it is an integer
+                num_header_lines = headerLines[z]
+        
+        # try to read in the file
+        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
+        if error:
+            output_data.append(f"{fname} is unable to be read as a table. {error}")
+            output_type.append("text")
+            status_data.append("FAILURE")
+            continue
+
+        # If any errors are found, the data will not pass the normalized check
+        normalization_errors_count = 0
+        normalization_errors_data = []
+
+        # Check for duplicate field names
+        duplicate_cols, contains_period = metadata.find_duplicate_column_names(df)
+        if duplicate_cols:
+            normalization_errors_count += 1
+            normalization_errors_data.append(f"{fname} contains duplicate columns: {', '.join(duplicate_cols)}")
+        elif contains_period:
+            # Add a warning if there's no duplicates and a period is found in the field
+            warn_msg = f"{fname} has periods '.' in the field names. We recommend replacing with underscores '_'"
+            normalization_errors_data.append(warn_msg)
+
+        # Check for duplicate column content
+        duplicate_col_content = metadata.find_duplicate_column_content(df)
+        if len(duplicate_col_content) != 0:
+            normalization_errors_count += 1
+            error_msg = "; ".join(
+                f"'{dup}' duplicates '{orig}' (hash: {h})"
+                for dup, orig, h in duplicate_col_content
+            )
+            normalization_errors_data.append(
+                f"{fname} contains duplicate column content: {error_msg}"
+            )
+
+        # Check for duplicate rows
+        duplicate_rows = metadata.find_duplicate_rows(df)
+        if duplicate_rows is not None:
+            dr_summary = duplicate_rows.to_markdown()
+            normalization_errors_count += 1
+            normalization_errors_data.append(
+                f"{fname} contains duplicate rows: \n{dr_summary} \n"
+            )
+
+        # Check for obscene amount of columns
+        num_of_cols = metadata.find_number_of_columns(df)
+        if num_of_cols >= 1000:
+            normalization_errors_count += 1
+            normalization_errors_data.append(
+                f"{fname} contains an excessive number of columns: {num_of_cols}"
+            )
+
+        # TODO: DISCUSS - Adding check for reasonable amount of non-repeating values
+
+        norm_errors_md_output = '\n'.join(f'| {line}' for line in normalization_errors_data)
+        if normalization_errors_count == 0:
+            if normalization_errors_data:
+                output_data.append(f"{fname} is normalized. Additional Details: {norm_errors_md_output}")
+            else:
+                output_data.append(f"{fname} is normalized.")
+            output_type.append("markdown")
+            status_data.append("SUCCESS")
+        else:
+            output_data.append(f"{fname} contains normalization issues: {norm_errors_md_output}")
+            output_type.append("markdown")
+            status_data.append("FAILURE")
+
+    successes = sum(x == "SUCCESS" for x in status_data)
+    failures = sum(x == "FAILURE" for x in status_data)
+    skips = sum(x == "SKIP" for x in status_data)
+    output = output_data
+    if successes > 0 and failures == 0:
+        status = "SUCCESS"
+    elif successes == 0 and failures > 0:
+        status = "FAILURE"
+    else:
+        status = "FAILURE" 
+
+    metadigpy_result["identifiers"] = output_identifiers
+    metadigpy_result["output"] = output_data
+    metadigpy_result["status"] = status
+    return True
+
+  ]]></code>
+  <selector>
+    <name>entityNames</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+    <subSelector>
+      <name>...</name>
+      <xpath>./entityName</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+    <name>objectNames</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+    <subSelector>
+      <name>...</name>
+      <xpath>./physical/objectName</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+    <name>ids</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]/@id</xpath>
+  </selector>
+  <selector>
+     <name>fieldDelimiter</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+     <subSelector>
+        <name>...</name>
+        <xpath>./physical/dataFormat/textFormat/simpleDelimited/fieldDelimiter</xpath>
+    </subSelector>
+  </selector>
+  <selector>
+     <name>headerLines</name>
+    <xpath>/eml/dataset/*[self::dataTable|self::otherEntity]</xpath>
+     <subSelector>
+        <name>...</name>
+        <xpath>./physical/dataFormat/textFormat/numHeaderLines</xpath>
+    </subSelector>
+  </selector>
+  <dialect>
+    <name>Ecological Metadata Language</name>
+    <xpath>boolean(/*[local-name() = 'eml'])</xpath>
+  </dialect>
+</mdq:check>

--- a/tests/testdata/checks/data.table-text-delimited.normalized.xml
+++ b/tests/testdata/checks/data.table-text-delimited.normalized.xml
@@ -53,7 +53,7 @@ def call():
             continue
 
         # Ensure that the data object is documented in the list of entity names
-        entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
+        entity_index = md.find_entity_index(fname, pid, entityNames, ids)
         if entity_index is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")

--- a/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
@@ -61,18 +61,19 @@ def call():
             continue
 
         # Set the default expecated header line value (the first row is headers)
-        num_header_lines = 1
+        num_header_lines = 0
         # headerLines represents 'numHeaderLines' which is retrieved from the EML document
         if isinstance(headerLines, list):
             # If we successfully retrieve a list, we will check what the value is
-            if headerLines[entity_index] == 'null':
+            header_line_value = headerLines[entity_index]
+            if header_line_value == 'null':
                 # There are no header lines
-                num_header_lines = 0
-            if isinstance(headerLines[entity_index], int):
+                pass
+            if isinstance(header_line_value, int):
                 # We'll use the value from the list of it is an integer
-                num_header_lines = headerLines[entity_index]
+                num_header_lines = header_line_value
         
-        # try to read in the file
+        # Read the data object
         obj_bytes_read = obj.read()
         encoding_type, enc_msg = md.detect_text_encoding(obj_bytes_read)
         d_read_decoded = obj_bytes_read.decode(encoding_type)
@@ -83,26 +84,41 @@ def call():
             status_data.append("FAILURE")
             continue
 
-
-        colnames = list(df.columns)
-        # extract the entity from the metadata doc and attributeNames
+        # Extract the entity from the metadata doc and attributeNames
         ent = md.find_eml_entity(document, pid, fname)
         att_names = [elem.text for elem in ent.findall(".//attributeName")]
-        # check if column names match documentation
-        if att_names == colnames:
+        col_names = list(df.columns)
+        if len(att_names) == 0:
+            output_data.append(f"Cannot find attribute names.")
+            output_type.append("markdown")
+            status_data.append("FAILURE")
+        # Check if column names match documentation
+        if att_names == col_names:
             output_data.append(f"{fname} variable names match documentation.")
             output_type.append("text")
             status_data.append("SUCCESS")
         else:
-            # Create a nice table to compare the variable names
-            table_rows = [
-                "| Attribute Names (Expected) | Variable Names (CSV) |",
-                "|----------------------------|----------------------|"
+            # Create a table to assist with comparing the variable names
+            # Get the max width so that we can insert the correct amount of spaces between pipes
+            att_name_mxw = max(
+                len("Attribute Names (Expected)"),
+                max(len(str(a)) for a in att_names)
+            )
+            col_name_mxw = max(
+                len("Variable Names (CSV)"),
+                max(len(str(c)) for c in col_names)
+            )
+            header = f"| {'Attribute Names (Expected)':<{att_name_mxw}} | {'Variable Names (CSV)':<{col_name_mxw}} |"
+            separator = f"|{'-' * (att_name_mxw + 2)}|{'-' * (col_name_mxw + 2)}|"
+            # Create the rows
+            rows = [
+                f"| {att:<{att_name_mxw}} | {col:<{col_name_mxw}} |"
+                for att, col in zip(att_names, col_names)
             ]
-            for att, col in zip(att_names, colnames):
-                table_rows.append(f"| {att} | {col} |")
-            joined_table_rows = '\n'.join(table_rows)
-            output_data.append(f"{fname} variable names do not match documentation.\n{joined_table_rows}")
+            row_list = [header, separator] + rows
+            table_rows = "\n".join(row_list)
+            # table_rows = "\n".join([header, separator] + rows)
+            output_data.append(f"{fname} variable names do not match documentation.\n{table_rows}")
             output_type.append("markdown")
             status_data.append("FAILURE")
 

--- a/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
@@ -18,7 +18,7 @@ def call():
     global metadigpy_result
 
     from metadig import StoreManager
-    import metadig as md
+    from metadig import metadata as md
     import pandas as pd
     import io
 
@@ -52,42 +52,37 @@ def call():
             status_data.append("FAILURE")
             continue
 
-        # read in all the data
-        d_read = obj.read().decode('utf-8', errors = 'replace')
-
-        # find which entity file is documented in
-        index_list = md.find_entity_index(fname, pid, entityNames, ids)
-        if index_list is None:
+        # Ensure that the data object is documented in the list of entity names
+        entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
+        if entity_index is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
-        # Set entity index number to the first item in the list
-        z = index_list[0]
 
-        # Set default value using the entity index
-        num_header_lines = z
+        # Set the default expecated header line value (the first row is headers)
+        num_header_lines = 1
         # headerLines represents 'numHeaderLines' which is retrieved from the EML document
         if isinstance(headerLines, list):
             # If we successfully retrieve a list, we will check what the value is
-            if headerLines[z] == 'null':
+            if headerLines[entity_index] == 'null':
                 # There are no header lines
                 num_header_lines = 0
-            if isinstance(headerLines[z], int):
+            if isinstance(headerLines[entity_index], int):
                 # We'll use the value from the list of it is an integer
-                num_header_lines = headerLines[z]
+                num_header_lines = headerLines[entity_index]
         
         # try to read in the file
-        df, error = md.read_csv_with_metadata(d_read, fieldDelimiter[z], num_header_lines)
+        obj_bytes_read = obj.read()
+        encoding_type, enc_msg = md.detect_text_encoding(obj_bytes_read)
+        d_read_decoded = obj_bytes_read.decode(encoding_type)
+        df, error = md.read_csv_with_metadata(d_read_decoded, fieldDelimiter[entity_index], num_header_lines, encoding_type)
         if error:
-            error_msg = (
-              f"{fname} is unable to be read as a table: {error}."
-              + f" Debug Info: entity index z: {z}. headerLines: {headerLines}"
-            )
-            output_data.append(error_msg)
+            output_data.append(f"{fname} is unable to be read as a table: {error}.")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
+
 
         colnames = list(df.columns)
         # extract the entity from the metadata doc and attributeNames
@@ -99,8 +94,16 @@ def call():
             output_type.append("text")
             status_data.append("SUCCESS")
         else:
-            output_data.append(f"{fname} variable names do not match documentation. Attribute names: {att_names}. Variable names: {colnames}")
-            output_type.append("text")
+            # Create a nice table to compare the variable names
+            table_rows = [
+                "| Attribute Names (Expected) | Variable Names (CSV) |",
+                "|----------------------------|----------------------|"
+            ]
+            for att, col in zip(att_names, colnames):
+                table_rows.append(f"| {att} | {col} |")
+            joined_table_rows = '\n'.join(table_rows)
+            output_data.append(f"{fname} variable names do not match documentation.\n{joined_table_rows}")
+            output_type.append("markdown")
             status_data.append("FAILURE")
 
     successes = sum(x == "SUCCESS" for x in status_data)

--- a/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
+++ b/tests/testdata/checks/data.table-text-delimited.variables-congruent.xml
@@ -53,7 +53,7 @@ def call():
             continue
 
         # Ensure that the data object is documented in the list of entity names
-        entity_index = md.find_entity_index(fname, pid, entityNames, ids)[0]
+        entity_index = md.find_entity_index(fname, pid, entityNames, ids)
         if entity_index is None:
             output_data.append(f"{fname} does not appear to be documented in the metadata.")
             output_type.append("text")

--- a/tests/testdata/checks/data.text-encoding.valid.xml
+++ b/tests/testdata/checks/data.text-encoding.valid.xml
@@ -6,7 +6,7 @@
   <name>Text data characters are encoded correctly</name>
   <description>Check that the text content is decodable and whether it's ascii or utf-8.</description>
   <type>identification</type>
-  <level>INFO</level>
+  <level>REQUIRED</level>
   <environment>python</environment>
   <code><![CDATA[
 
@@ -36,31 +36,37 @@ def call():
 
         # If data object is not available, skip the pid.
         try:
-          obj, sys = manager.get_object(pid)
-          fname = md.read_sysmeta_element(sys, "fileName")
+            obj, sys = manager.get_object(pid)
+            fname = md.read_sysmeta_element(sys, "fileName")
+            format_id = md.read_sysmeta_element(sys, "formatId")
         except Exception as e:
             output_data.append(f"Unexpected Exception: {e}")
             output_type.append("text")
             status_data.append("FAILURE")
             continue
 
-        # Check character encoding
-        bytes_read = obj.read()
-        enc_type, msg = md.detect_text_encoding(bytes_read)
-        # TODO: Discuss whether we should also look for characters that can cause
-        #       parsing concerns like \n, \t and add a warning
-        if enc_type == "ascii":
-            output_data.append(f"{fname} is a valid 'ascii' document and does not contain encoding errors.")
-            output_type.append("text")
-            status_data.append("SUCCESS")
-        elif enc_type == "utf-8":
-            output_data.append(f"{fname} is a valid 'utf-8' document and does not contain encoding errors.")
-            output_type.append("text")
-            status_data.append("SUCCESS")
+        if format_id.startswith("text/"):
+            # Check character encoding
+            bytes_read = obj.read()
+            enc_type, msg = md.detect_text_encoding(bytes_read)
+            # TODO: Discuss whether we should also look for characters that can cause
+            #       parsing concerns like \n, \t and add a warning
+            if enc_type == "ascii":
+                output_data.append(f"`{fname}` is a valid 'ascii' document and does not contain encoding errors.")
+                output_type.append("markdown")
+                status_data.append("SUCCESS")
+            elif enc_type == "utf-8":
+                output_data.append(f"`{fname}` is a valid 'utf-8' document and does not contain encoding errors.")
+                output_type.append("markdown")
+                status_data.append("SUCCESS")
+            else:
+                # TODO: For now, we will only accept valid 'utf-8' and 'ascii' documents as a SUCCESS
+                #       Discuss if we should have specific standards, or should proceed in another path
+                output_data.append(f"`{fname}` has been detected as a '{enc_type}' document. {msg}.")
+                output_type.append("markdown")
+                status_data.append("FAILURE")
         else:
-            # TODO: For now, we will only accept valid 'utf-8' and 'ascii' documents as a SUCCESS
-            #       Discuss if we should have specific standards, or should proceed in another path
-            output_data.append(f"{fname} has been detected as a '{enc_type}' document, and may contain errors: {msg}.")
+            output_data.append(f"`{fname}` is not a text document.")
             output_type.append("text")
             status_data.append("FAILURE")
 

--- a/tests/testdata/test-data_duplicate_columns.csv
+++ b/tests/testdata/test-data_duplicate_columns.csv
@@ -1,0 +1,235 @@
+Year,Site,Species,Nest_lat,Nest_lon,Date,Date,Num_indiv,Num_indiv,Nest_contents,Notes
+2011,barr,poja,71.35783,-156.35123,24-Jun-10,24-Jun-10,3,3,e,Both adults defending territory
+2012,barr,paja,71.26184,-156.5418,13-Jun-12,13-Jun-12,unknown,unknown,u,"location approximate; did not go to nest - adults chasing pefa, glgu away and sitting on ground in area"
+2012,barr,arfo,71.27126,-156.56042,17-Jun-12,17-Jun-12,4,4,y,800m w plot 3; no adult seen; pups going in and out of den (only 4 seen); told fox crew about it and they disposed of it quickly
+2012,barr,snow,71.29257,-156.64194,25-May-12,25-May-12,7,7,e,7e total; only 2 when found; on plot 2 in quadrat g13
+2012,barr,paja,71.28756,-156.6452,9-Jun-12,9-Jun-12,1,1,e,250m south of plot 2. female? was sitting on nest. male chased poja
+2013,barr,paja,71.26559,-156.54453,2-Jul-13,2-Jul-13,2,2,e,Nest seen by Rick Lanctot while searching for geo AMGP. Located about 300m west of D1 on plot 5
+2013,barr,paja,71.24587,-156.57292,25-Jun-13,25-Jun-13,2,2,e,"found 19 June, hatch 13 July"
+2013,barr,paja,71.30219,-156.63745,25-Jun-13,25-Jun-13,2,2,e,"NE of A13 Plot 1, a Brant nest in ca 100 m distance"
+2013,barr,paja,71.28745,-156.64046,16-Jul-13,16-Jul-13,,,,"probably young, couldn't find nest but very broody behaviour "
+2014,barr,poja,71.28343,-156.58113,25-Jun-14,25-Jun-14,1,1,e,
+2014,barr,paja,71.24556,-156.57628,18-Jun-14,18-Jun-14,2,2,e,
+2014,barr,snow,,,26-May-14,26-May-14,9,9,e,"Near stake I10 on Plot 2.  7 chicks hatched, 3 survived to leave the nest.  Chicks last seen wandering around the north end of Plot 2 early August."
+2014,burn,herg,55.25621,-84.29432,12-Jun-14,12-Jun-14,3,3,e,
+2014,bylo,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2011,cakr,glgu,67.11437,-163.47354,7-Jun-11,7-Jun-11,3,3,e,both adults defending territory
+2011,cakr,sacr,67.11426,-163.47861,7-Jun-11,7-Jun-11,2,2,e,"both adults defedended terriotry, nest depredated June 11th"
+2011,cakr,paja,67.1138,-163.49982,13-Jun-11,13-Jun-11,2,2,e,"both adults defended terriotry, one chick hatched June 22nd "
+2012,cakr,sacr,67.09837,-163.48256,23-Jun-12,23-Jun-12,1,1,e,"One egg has been depredated. Found shell at 3m from nest. Paja depredation? Shell pieces in nest, the remained egg have one little hole, but the membrane is not broken. The cranes were not there in the morning but came back in the afternoon around nest. "
+2012,cakr,sacr,67.09837,-163.48256,1-Jul-12,1-Jul-12,1,1,e,Still one egg and sacr around
+2012,cakr,paja,67.09783,-163.4838,23-Jun-12,23-Jun-12,2,2,e,
+2012,cakr,paja,67.09783,-163.4838,1-Jul-12,1-Jul-12,2,2,e,
+2012,cakr,paja,67.09783,-163.4838,6-Jul-12,6-Jul-12,2,2,e,
+2012,cakr,paja,67.11375,-163.50108,22-Jun-12,22-Jun-12,1,1,e,
+2012,cakr,paja,67.11375,-163.50108,11-Jun-12,11-Jun-12,1,1,e,1 egg depredated by common raven. Raven seen and they were 2 eggs at one point
+2012,cakr,paja,67.11375,-163.50108,1-Jun-12,1-Jun-12,1,1,e,"parent on one egg, very cold outside. They are laying"
+2012,cakr,paja,67.11375,-163.50108,3-Jul-12,3-Jul-12,1,1,y,1 one seen at 40m from nest. Paja are very crazy!! Nothing in the nest
+2013,cakr,refo,67.1117,-163.48454,,,unknown,unknown,u,"did not observe individuals entering den, but saw fresh tracks and know it was being used"
+2013,cakr,refo,67.11473,-163.46387,,,1,1,u,only observed one individual entering den.
+2014,cakr,paja,67.11418,-163.47653,5-Jun-14,5-Jun-14,2,2,e,1 egg. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,10-Jun-14,10-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,15-Jun-14,15-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,20-Jun-14,20-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,25-Jun-14,25-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,29-May-14,29-May-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,4-Jun-14,4-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,10-Jun-14,10-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,15-Jun-14,15-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,20-Jun-14,20-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,21-Jun-14,21-Jun-14,2,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,22-Jun-14,22-Jun-14,2,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,23-Jun-14,23-Jun-14,2,2,y,Both chicks hatched. Out of nest.
+2014,cakr,refo,67.11353,-163.55293,14-Jun-14,14-Jun-14,1,1,u,"Fox den off plot, near this point"
+2011,cari,snow,70.12315,-145.81639,9-Jun-11,9-Jun-11,2,2,e,7 eggs; Nest number 105SNOW. Nest failed 20 June.
+2011,cari,poja,70.10955,-145.82129,17-Jun-11,17-Jun-11,2,2,e,"2 eggs;Nest number 215POJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,paja,70.11593,-145.82785,17-Jun-11,17-Jun-11,2,2,e,"2 eggs;Nest number 729PAJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,snow,70.13077,-145.83925,7-Jun-11,7-Jun-11,2,2,e,6 eggs; nest number 602SNOW. Nest failed 18 June.
+2011,cari,snow,70.09887,-145.8436,10-Jun-11,10-Jun-11,2,2,e,6 eggs; nest number 505SNOW. Nest failed 8 July.
+2011,cari,paja,70.12663,-145.84491,5-Jul-11,5-Jul-11,2,2,e,2 eggs;Nest number 176PAJA. Fate undetermined.
+2011,cari,arfo,70.11439,-145.84871,5-Jul-11,5-Jul-11,2,2,y,"~15 kits. Foxes frequently in study area, sometimes seen with dead adult shorebirds, likely cause of many depredated nests."
+2012,cari,paja,70.10468,-145.81955,19-Jun-12,19-Jun-12,2,2,e,nest failed 24 june
+2012,cari,paja,70.11613,-145.82742,11-Jun-12,11-Jun-12,2,2,e,nest failed 24 june
+2012,cari,glgu,70.10606,-145.82823,7-Jun-12,7-Jun-12,1,1,e,nest fate unknown
+2012,cari,rutu,70.11002,-145.84404,11-Jun-12,11-Jun-12,4,4,e,nest failed 16 june
+2012,cari,rutu,70.10709,-145.84717,14-Jun-12,14-Jun-12,2,2,e,nest failed 15 june
+2012,cari,rutu,70.1086,-145.84981,5-Jul-12,5-Jul-12,4,4,e,nest hatched to 4 chicks on 10-Jul
+2012,cari,glgu,70.12421,-145.85675,13-Jun-12,13-Jun-12,3,3,e,nest failed 20 jun
+2012,cari,glgu,70.1236,-145.85788,13-Jun-12,13-Jun-12,unknown,unknown,u,nest hatched at least 1 chick
+2013,cari,paja,70.11555,-145.832549,15-Jun-13,15-Jun-13,2,2,e,2 eggs;nest failed 26-Jun
+2013,cari,rutu,70.10954,-145.84889,19-Jun-13,19-Jun-13,2,2,e,4 eggs; nest failed 28-Jun
+2013,cari,glgu,70.09294,-145.884872,20-Jun-13,20-Jun-13,2,2,e,2 eggs;nest failed 25-Jun
+2013,cari,rutu,70.10681,-145.884937,25-Jun-13,25-Jun-13,2,2,e,4 eggs; nest hatched 28-Jun
+2013,cari,glgu,70.12439,-145.88544,14-Jun-13,14-Jun-13,2,2,e,3 eggs; hatched before 19-July
+2013,cari,glgu,70.12394,-145.885841,14-Jun-13,14-Jun-13,2,2,e,3 eggs
+2014,cari,snow,70.12363,-145.79929,15-Jun-14,15-Jun-14,6,6,e,2c on 7 jul
+2014,cari,poja,70.11937,-145.8163,16-Jun-14,16-Jun-14,1,1,e,fail 28 jun
+2014,cari,paja,70.11582,-145.82393,15-Jun-14,15-Jun-14,2,2,e,hatch 10 jul
+2014,cari,seow,70.11781,-145.83875,19-Jun-14,19-Jun-14,7,7,e,fail 19 jun
+2014,cari,rutu,70.10986,-145.84076,12-Jun-14,12-Jun-14,4,4,e,failed 22 jun
+2014,cari,rutu,70.10974,-145.84128,24-Jun-14,24-Jun-14,2,2,e,hatch 14 jul
+2014,cari,arfo,70.11565,-145.84196,7-Jun-14,7-Jun-14,7,7,y,7 kits counted
+2014,cari,rutu,70.10999,-145.84482,1-Jul-14,1-Jul-14,1,1,e,hatch 2 jul
+2014,cari,glgu,70.12481,-145.85648,9-Jun-14,9-Jun-14,,,,failed prior to 25 jun
+2012,chau,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2013,chau,agsq,68.77785,170.54257,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77591,170.5463,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,glgu,68.78194,170.54828,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.77802,170.54875,7-Jun-13,7-Jun-13,2,2,e,
+2013,chau,sacr,68.77802,170.54875,25-Jun-13,25-Jun-13,1,1,e,
+2013,chau,agsq,68.77438,170.54961,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.78691,170.5504,,,unknown,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.77563 E 170.55251
+2013,chau,sacr,68.78599,170.55077,20-Jun-13,20-Jun-13,2,2,e,
+2013,chau,agsq,68.78114,170.55141,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77563,170.55251,,,unknown,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.78691 E 170.5504
+2013,chau,glgu,68.78867,170.565,,,3,3,e,
+2013,chau,glgu,68.78022,170.56873,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,glgu,68.7852,170.5692,,,unknown,unknown,u,
+2013,chau,glgu,68.78053,170.56934,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.78036,170.57353,9-Jun-13,9-Jun-13,2,2,e,
+2013,chau,glgu,68.78247,170.57466,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2014,chau,agsq,68.77795,170.54265,25-Jun-14,25-Jun-14,unknown,unknown,u,unable to see inside den
+2014,chau,agsq,68.78192,170.54387,18-Jun-14,18-Jun-14,2,2,u,unable to see inside den.  Individuals appeard to be adults.  West 1/5 of ASDN surveyed
+2014,chau,glgu,68.78194,170.54828,12-Jun-14,12-Jun-14,unknown,unknown,u,Adult sitting on nest.  Unable to see contence of nest.  Nest on island surounded by deep water.
+2014,chau,glgu,68.78213,170.54851,25-Jun-14,25-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.77738,170.54878,14-Jun-14,14-Jun-14,6,6,u,unable to see inside den.
+2014,chau,vegu,68.7858,170.55478,25-Jun-14,25-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.78287,170.55822,12-Jun-14,12-Jun-14,1,1,u,"Unable to see inside den. Original GPS point lost, this GPS location is an estimate. "
+2014,chau,glgu,68.78022,170.56873,23-Jun-14,23-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2012,chur,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2014,chur,paja,58.74163,-93.87878,15-Jun-14,15-Jun-14,2,2,u,"Observed adult sitting on nest, approached location and both adults defending nest with distraction displays, coordinates are approximate"
+2014,chur,paja,58.7432,-93.96733,4-Jun-14,4-Jun-14,2,2,2 e,Both adults defending territory
+2014,chur,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2014,coat,paja,62.86806,-82.49583,22-Jun-14,22-Jun-14,2,2,e,both adults acting like wimps defending territory
+2011,colv,rutu,70.42844,-150.66515,20-Jun-11,20-Jun-11,4,4,e,Adult defending territory
+2011,colv,rutu,70.42094,-150.66696,18-Jun-11,18-Jun-11,2,2,e,Both adults defending territory
+2011,colv,rutu,70.43555,-150.67552,14-Jun-11,14-Jun-11,3,3,e,Adult defending territory
+2011,colv,paja,70.42522,-150.67624,13-Jun-11,13-Jun-11,1,1,e,Both adults defending territory
+2011,colv,ltja,70.43938,-150.68398,7-Jun-11,7-Jun-11,2,2,e,Both adults defending territory
+2011,colv,rutu,70.43834,-150.68408,18-Jun-11,18-Jun-11,3,3,e,Adult defending territory
+2011,colv,rutu,70.43929,-150.6861,15-Jun-11,15-Jun-11,3,3,e,Adult defending territory
+2011,colv,rutu,70.43987,-150.6893,18-Jun-11,18-Jun-11,2,2,e,Adult defending territory
+2011,colv,glgu,70.43618,-150.70061,16-Jun-11,16-Jun-11,3,3,e,Both adults defending territory
+2011,colv,rutu,70.44189,-150.70624,18-Jun-11,18-Jun-11,4,4,e,Both adults defending territory
+2012,colv,rutu,70.42723,-150.66489,3-Jul-12,3-Jul-12,3,3,e,
+2012,colv,refo,70.42142,-150.66614,16-Jun-12,16-Jun-12,,,y,had 8 young around den later in year
+2012,colv,rutu,70.41962,-150.66731,11-Jun-12,11-Jun-12,4,4,e,
+2012,colv,paja,70.42522,-150.67624,13-Jun-12,13-Jun-12,2,2,e,
+2012,colv,rutu,70.43257,-150.67958,10-Jun-12,10-Jun-12,2,2,e,
+2012,colv,rutu,70.44202,-150.69092,18-Jun-12,18-Jun-12,4,4,e,
+2013,colv,rutu,70.42816,-150.65996,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43051,-150.66,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.42064,-150.66016,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,ltja,70.425,-150.66467,20-Jun-13,20-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.42792,-150.6647,20-Jun-13,20-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43369,-150.675,16-Jun-13,16-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43494,-150.67532,2-Jun-13,2-Jun-13,0,0,e,
+2013,colv,paja,70.42592,-150.67801,26-Jun-13,26-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43761,-150.68243,18-Jun-13,18-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.44012,-150.68753,16-Jun-13,16-Jun-13,2,2,e,Both adults defending territory
+2013,colv,ltja,70.43972,-150.68816,12-Jun-13,12-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.44442,-150.69423,25-Jun-13,25-Jun-13,2,2,e,Both adults defending territory
+2014,colv,rutu,70.42586,-150.66476,10-Jun-14,10-Jun-14,4,4,e,
+2014,colv,refo,70.41237,-150.66621,3-Jun-14,3-Jun-14,3,3,y,1 adult present defending territory
+2014,colv,refo,70.41237,-150.66621,5-Jun-14,5-Jun-14,3,3,y,
+2014,colv,refo,70.41237,-150.66621,7-Jun-14,7-Jun-14,1,1,y,
+2014,colv,refo,70.41237,-150.66621,10-Jun-14,10-Jun-14,4,4,y,
+2014,colv,refo,70.41237,-150.66621,11-Jun-14,11-Jun-14,2,2,y,Both adults defending territory
+2014,colv,refo,70.41237,-150.66621,17-Jun-14,17-Jun-14,1,1,y,
+2014,colv,rutu,70.43016,-150.66713,10-Jun-14,10-Jun-14,4,4,e,
+2014,colv,rutu,70.42637,-150.66728,25-Jun-14,25-Jun-14,4,4,e,
+2014,colv,rutu,70.43123,-150.66792,11-Jun-14,11-Jun-14,4,4,e,
+2014,colv,cole,70.42586,-150.67499,7-Jun-14,7-Jun-14,1,1,adult,
+2014,colv,paja,70.42472,-150.67702,11-Jun-14,11-Jun-14,2,2,e,At least 1 chick observed hatched
+2014,colv,rutu,70.43823,-150.67867,13-Jun-14,13-Jun-14,3,3,e,
+2014,colv,rutu,70.43853,-150.68251,12-Jun-14,12-Jun-14,4,4,e,
+2014,colv,rutu,70.43929,-150.68611,21-Jun-14,21-Jun-14,4,4,e,
+2014,colv,rutu,70.43946,-150.6868,16-Jun-14,16-Jun-14,4,4,e,
+2014,colv,rutu,70.44868,-150.70607,29-Jun-14,29-Jun-14,4,4,e,
+2014,colv,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2012,eaba,herg,64.00547,-81.66993,19-Jun-12,19-Jun-12,2,2,e,"slightly territorial (1 hanging out around head, making alarm call)"
+2012,eaba,herg,63.9913,-81.72952,20-Jun-12,20-Jun-12,2,2,u,"1 adult defending strongly (v. close, persistant dive-bombing.  1 adult remained at nest, not sitting, called in 8 birds total flying overhead, unable to reach nest (too much aggression)"
+2012,eaba,herg,64.00547222,-81.66991667,19-Jun-12,19-Jun-12,2,2,e,1 egg
+2012,eaba,paja,63.99688889,-81.67402778,24-Jun-12,24-Jun-12,2,2,e,"2 eggs;pair of PAJA, broken wing display when we approached, when that didn't work they took to the air and dive-bombed us"
+2012,eaba,herg,63.99688889,-81.70175,24-Jun-12,24-Jun-12,3,3,e,"2 eggs; three hergs in total, nest was out in the middle of the water, they dive bombed when we approached"
+2012,eaba,herg,63.99205556,-81.71825,28-Jun-12,28-Jun-12,2,2,u,loon nest on same patch of land as HERG nest
+2012,eaba,herg,63.98211111,-81.72658333,12-Jun-12,12-Jun-12,12,12,e,1 egg; many adults defending nest
+2012,eaba,herg,63.98916667,-81.73230556,12-Jun-12,12-Jun-12,5,5,e,1 egg; many adults defending nest
+2012,eaba,paja,63.97872222,-81.71125,21-Jun-12,21-Jun-12,2,2,e,"2 eggs in nest, both adults very territorial: dive-bombing, calling, broken-wing display."
+2013,iglo,arfo,69.411991,-81.516148,20-Jul-13,20-Jul-13,2,2,,
+2014,iglo,ltja,69.38385,-81.60727,9-Jul-14,9-Jul-14,1,1,e,
+2014,iglo,ltja,69.38808,-81.55575,27-Jun-14,27-Jun-14,1,1,e,
+2014,iglo,rutu,69.40118,-81.54959,25-Jun-14,25-Jun-14,4,4,e,
+2014,iglo,rutu,69.40253,-81.53867,24-Jun-14,24-Jun-14,2,2,e,
+2014,iglo,herg/thgu,69.41021,-81.52865,29-Jun-14,29-Jun-14,2,2,e,
+2011,ikpi,agsq,70.54684,-154.66409,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,glgu,70.54747,-154.66608,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,glgu,70.54736,-154.66624,28-Jun-11,28-Jun-11,,,,incubating
+2011,ikpi,agsq,70.54521,-154.66698,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54388,-154.66975,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,seow,70.5501,-154.6722,30-Jun-11,30-Jun-11,5,5,e,
+2011,ikpi,agsq,70.54324,-154.67381,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.5427,-154.67409,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54241,-154.67596,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54193,-154.6805,14-Jul-11,14-Jul-11,,,,
+2011,ikpi,seow,70.53378,-154.68599,6-Jun-11,6-Jun-11,3,3,e,
+2011,ikpi,glgu,70.54389,-154.69827,13-Jun-11,13-Jun-11,,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,glgu,70.53801,-154.69958,11-Jun-11,11-Jun-11,,,,
+2011,ikpi,glgu,70.54469,-154.71005,13-Jun-11,13-Jun-11,,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,agsq,70.56364,-154.71143,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,agsq,70.56532,-154.71188,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,agsq,70.56535,-154.71197,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,agsq,70.57728,-154.7123,10-Jun-11,10-Jun-11,,,,
+2011,ikpi,agsq,70.5636,-154.71332,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,agsq,70.56361,-154.71332,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,seow,70.536883,-154.71361,16-Jul-11,16-Jul-11,6,6,y,6 CHICKS IN NEST 1 CHICK 20M FROM NEST
+2011,ikpi,agsq,70.56477,-154.71465,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,ltja,70.53659,-154.74094,12-Jun-11,12-Jun-11,,,e,
+2011,ikpi,agsq,70.53093,-154.75005,12-Jun-11,12-Jun-11,,,,
+2011,ikpi,glgu,70.53887,-154.75327,17-Jun-11,17-Jun-11,,,e,3 eggs
+2011,ikpi,seow,,,21-Jun-11,21-Jun-11,2,2,,"unknown nest contents, nest on plot 1 but no coordinates taken"
+2013,ikpi,agsq,70.55009,-154.65993,11-Jun-13,11-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54128,-154.68626,27-Jun-13,27-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54126,-154.68637,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55743,-154.68756,14-Jun-13,14-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55746,-154.68771,8-Jun-13,8-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54723,-154.6938,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54724,-154.69383,17-Jun-13,17-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,glgu,70.54456,-154.69501,24-Jun-13,24-Jun-13,unknown,unknown,u,contents not seen
+2013,ikpi,agsq,70.54971,-154.70293,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54377,-154.7037,13-Jun-13,13-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.548,-154.71068,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.56696,-154.71089,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,paja,70.55904,-154.71361,2-Jul-13,2-Jul-13,2,2,e,Both adults defending territory
+2013,ikpi,agsq,70.55781,-154.72096,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55762,-154.72266,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2014,ikpi,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2012,lkri,ltja,72.8647,-106.0243,22-Jun-12,22-Jun-12,1,1,e,
+2012,lkri,paja,72.8261,-106.0605,7-Jul-12,7-Jul-12,2,2,e,
+2012,lkri,herg,72.837,-106.0747,13-Jul-12,13-Jul-12,3,3,e,
+2012,lkri,pefa,72.9321,-106.1042,11-Jul-12,11-Jul-12,4,4,e,
+2011,made,paja,69.34713829,-134.9102705,7-Jun-11,7-Jun-11,2,2,e,both adults in attack mode
+2011,made,paja,69.32381228,-135.3465797,10-Jun-11,10-Jun-11,1,1,e,
+2013,made,gyrf,69.37099,-134.88817,30-Jun-13,30-Jun-13,2,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,7-Jul-13,7-Jul-13,2,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,9-Jun-13,9-Jun-13,2,2,y,"Both adults defending territory, 4 chicks"
+2013,made,paja,69.3756,-134.95963,11-Jun-13,11-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,16-Jun-13,16-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,23-Jun-13,23-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2014,made,sacr,69.44953,-135.1624,25-Jun-14,25-Jun-14,2,2,e,
+2014,made,sacr,69.37762,-134.96043,10-Jun-14,10-Jun-14,1,1,e,
+2014,made,sacr,69.37032,-134.89946,7-Jun-14,7-Jun-14,2,2,e,
+2014,made,glgu,69.3529,-134.89166,23-Jun-14,23-Jun-14,3,3,e,
+2014,made,glgu,69.35506,-134.88759,23-Jun-14,23-Jun-14,3,3,e,
+2014,made,sacr,69.36963,-134.87822,9-Jun-14,9-Jun-14,1,1,e,
+2014,made,glgu,69.36726,-134.86641,16-Jun-14,16-Jun-14,3,3,e,
+2014,made,glgu,69.36774,-134.86429,16-Jun-14,16-Jun-14,2,2,e,
+2012,prba,ltja,70.21669,-148.51195,8-Jun-12,8-Jun-12,2,2,e,
+2012,prba,paja,70.35298,-148.61705,16-Jun-12,16-Jun-12,1,1,e,
+2012,prba,ltja,70.35362,-148.78622,20-Jun-12,20-Jun-12,2,2,e,
+2014,prba,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2004,coat,herg,,,28-Jun-04,28-Jun-04,,,,
+2004,coat,herg,,,10-Jul-04,10-Jul-04,,,,
+2004,coat,paja,62.87864,-82.48539,4-Jul-04,4-Jul-04,,,e,
+2005,coat,herg,,,19-Jun-05,19-Jun-05,,,e,

--- a/tests/testdata/test-data_duplicate_columns_dif_names.csv
+++ b/tests/testdata/test-data_duplicate_columns_dif_names.csv
@@ -1,0 +1,235 @@
+Year,Site,Species,Nest_lat,Nest_lon,Date,Date_dupe,Num_indiv,Num_indiv_dupe,Nest_contents,Notes
+2011,barr,poja,71.35783,-156.35123,24-Jun-10,24-Jun-10,3,3,e,Both adults defending territory
+2012,barr,paja,71.26184,-156.5418,13-Jun-12,13-Jun-12,unknown,unknown,u,"location approximate; did not go to nest - adults chasing pefa, glgu away and sitting on ground in area"
+2012,barr,arfo,71.27126,-156.56042,17-Jun-12,17-Jun-12,4,4,y,800m w plot 3; no adult seen; pups going in and out of den (only 4 seen); told fox crew about it and they disposed of it quickly
+2012,barr,snow,71.29257,-156.64194,25-May-12,25-May-12,7,7,e,7e total; only 2 when found; on plot 2 in quadrat g13
+2012,barr,paja,71.28756,-156.6452,9-Jun-12,9-Jun-12,1,1,e,250m south of plot 2. female? was sitting on nest. male chased poja
+2013,barr,paja,71.26559,-156.54453,2-Jul-13,2-Jul-13,2,2,e,Nest seen by Rick Lanctot while searching for geo AMGP. Located about 300m west of D1 on plot 5
+2013,barr,paja,71.24587,-156.57292,25-Jun-13,25-Jun-13,2,2,e,"found 19 June, hatch 13 July"
+2013,barr,paja,71.30219,-156.63745,25-Jun-13,25-Jun-13,2,2,e,"NE of A13 Plot 1, a Brant nest in ca 100 m distance"
+2013,barr,paja,71.28745,-156.64046,16-Jul-13,16-Jul-13,,,,"probably young, couldn't find nest but very broody behaviour "
+2014,barr,poja,71.28343,-156.58113,25-Jun-14,25-Jun-14,1,1,e,
+2014,barr,paja,71.24556,-156.57628,18-Jun-14,18-Jun-14,2,2,e,
+2014,barr,snow,,,26-May-14,26-May-14,9,9,e,"Near stake I10 on Plot 2.  7 chicks hatched, 3 survived to leave the nest.  Chicks last seen wandering around the north end of Plot 2 early August."
+2014,burn,herg,55.25621,-84.29432,12-Jun-14,12-Jun-14,3,3,e,
+2014,bylo,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2011,cakr,glgu,67.11437,-163.47354,7-Jun-11,7-Jun-11,3,3,e,both adults defending territory
+2011,cakr,sacr,67.11426,-163.47861,7-Jun-11,7-Jun-11,2,2,e,"both adults defedended terriotry, nest depredated June 11th"
+2011,cakr,paja,67.1138,-163.49982,13-Jun-11,13-Jun-11,2,2,e,"both adults defended terriotry, one chick hatched June 22nd "
+2012,cakr,sacr,67.09837,-163.48256,23-Jun-12,23-Jun-12,1,1,e,"One egg has been depredated. Found shell at 3m from nest. Paja depredation? Shell pieces in nest, the remained egg have one little hole, but the membrane is not broken. The cranes were not there in the morning but came back in the afternoon around nest. "
+2012,cakr,sacr,67.09837,-163.48256,1-Jul-12,1-Jul-12,1,1,e,Still one egg and sacr around
+2012,cakr,paja,67.09783,-163.4838,23-Jun-12,23-Jun-12,2,2,e,
+2012,cakr,paja,67.09783,-163.4838,1-Jul-12,1-Jul-12,2,2,e,
+2012,cakr,paja,67.09783,-163.4838,6-Jul-12,6-Jul-12,2,2,e,
+2012,cakr,paja,67.11375,-163.50108,22-Jun-12,22-Jun-12,1,1,e,
+2012,cakr,paja,67.11375,-163.50108,11-Jun-12,11-Jun-12,1,1,e,1 egg depredated by common raven. Raven seen and they were 2 eggs at one point
+2012,cakr,paja,67.11375,-163.50108,1-Jun-12,1-Jun-12,1,1,e,"parent on one egg, very cold outside. They are laying"
+2012,cakr,paja,67.11375,-163.50108,3-Jul-12,3-Jul-12,1,1,y,1 one seen at 40m from nest. Paja are very crazy!! Nothing in the nest
+2013,cakr,refo,67.1117,-163.48454,,,unknown,unknown,u,"did not observe individuals entering den, but saw fresh tracks and know it was being used"
+2013,cakr,refo,67.11473,-163.46387,,,1,1,u,only observed one individual entering den.
+2014,cakr,paja,67.11418,-163.47653,5-Jun-14,5-Jun-14,2,2,e,1 egg. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,10-Jun-14,10-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,15-Jun-14,15-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,20-Jun-14,20-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,25-Jun-14,25-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,29-May-14,29-May-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,4-Jun-14,4-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,10-Jun-14,10-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,15-Jun-14,15-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,20-Jun-14,20-Jun-14,2,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,21-Jun-14,21-Jun-14,2,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,22-Jun-14,22-Jun-14,2,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,23-Jun-14,23-Jun-14,2,2,y,Both chicks hatched. Out of nest.
+2014,cakr,refo,67.11353,-163.55293,14-Jun-14,14-Jun-14,1,1,u,"Fox den off plot, near this point"
+2011,cari,snow,70.12315,-145.81639,9-Jun-11,9-Jun-11,2,2,e,7 eggs; Nest number 105SNOW. Nest failed 20 June.
+2011,cari,poja,70.10955,-145.82129,17-Jun-11,17-Jun-11,2,2,e,"2 eggs;Nest number 215POJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,paja,70.11593,-145.82785,17-Jun-11,17-Jun-11,2,2,e,"2 eggs;Nest number 729PAJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,snow,70.13077,-145.83925,7-Jun-11,7-Jun-11,2,2,e,6 eggs; nest number 602SNOW. Nest failed 18 June.
+2011,cari,snow,70.09887,-145.8436,10-Jun-11,10-Jun-11,2,2,e,6 eggs; nest number 505SNOW. Nest failed 8 July.
+2011,cari,paja,70.12663,-145.84491,5-Jul-11,5-Jul-11,2,2,e,2 eggs;Nest number 176PAJA. Fate undetermined.
+2011,cari,arfo,70.11439,-145.84871,5-Jul-11,5-Jul-11,2,2,y,"~15 kits. Foxes frequently in study area, sometimes seen with dead adult shorebirds, likely cause of many depredated nests."
+2012,cari,paja,70.10468,-145.81955,19-Jun-12,19-Jun-12,2,2,e,nest failed 24 june
+2012,cari,paja,70.11613,-145.82742,11-Jun-12,11-Jun-12,2,2,e,nest failed 24 june
+2012,cari,glgu,70.10606,-145.82823,7-Jun-12,7-Jun-12,1,1,e,nest fate unknown
+2012,cari,rutu,70.11002,-145.84404,11-Jun-12,11-Jun-12,4,4,e,nest failed 16 june
+2012,cari,rutu,70.10709,-145.84717,14-Jun-12,14-Jun-12,2,2,e,nest failed 15 june
+2012,cari,rutu,70.1086,-145.84981,5-Jul-12,5-Jul-12,4,4,e,nest hatched to 4 chicks on 10-Jul
+2012,cari,glgu,70.12421,-145.85675,13-Jun-12,13-Jun-12,3,3,e,nest failed 20 jun
+2012,cari,glgu,70.1236,-145.85788,13-Jun-12,13-Jun-12,unknown,unknown,u,nest hatched at least 1 chick
+2013,cari,paja,70.11555,-145.832549,15-Jun-13,15-Jun-13,2,2,e,2 eggs;nest failed 26-Jun
+2013,cari,rutu,70.10954,-145.84889,19-Jun-13,19-Jun-13,2,2,e,4 eggs; nest failed 28-Jun
+2013,cari,glgu,70.09294,-145.884872,20-Jun-13,20-Jun-13,2,2,e,2 eggs;nest failed 25-Jun
+2013,cari,rutu,70.10681,-145.884937,25-Jun-13,25-Jun-13,2,2,e,4 eggs; nest hatched 28-Jun
+2013,cari,glgu,70.12439,-145.88544,14-Jun-13,14-Jun-13,2,2,e,3 eggs; hatched before 19-July
+2013,cari,glgu,70.12394,-145.885841,14-Jun-13,14-Jun-13,2,2,e,3 eggs
+2014,cari,snow,70.12363,-145.79929,15-Jun-14,15-Jun-14,6,6,e,2c on 7 jul
+2014,cari,poja,70.11937,-145.8163,16-Jun-14,16-Jun-14,1,1,e,fail 28 jun
+2014,cari,paja,70.11582,-145.82393,15-Jun-14,15-Jun-14,2,2,e,hatch 10 jul
+2014,cari,seow,70.11781,-145.83875,19-Jun-14,19-Jun-14,7,7,e,fail 19 jun
+2014,cari,rutu,70.10986,-145.84076,12-Jun-14,12-Jun-14,4,4,e,failed 22 jun
+2014,cari,rutu,70.10974,-145.84128,24-Jun-14,24-Jun-14,2,2,e,hatch 14 jul
+2014,cari,arfo,70.11565,-145.84196,7-Jun-14,7-Jun-14,7,7,y,7 kits counted
+2014,cari,rutu,70.10999,-145.84482,1-Jul-14,1-Jul-14,1,1,e,hatch 2 jul
+2014,cari,glgu,70.12481,-145.85648,9-Jun-14,9-Jun-14,,,,failed prior to 25 jun
+2012,chau,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2013,chau,agsq,68.77785,170.54257,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77591,170.5463,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,glgu,68.78194,170.54828,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.77802,170.54875,7-Jun-13,7-Jun-13,2,2,e,
+2013,chau,sacr,68.77802,170.54875,25-Jun-13,25-Jun-13,1,1,e,
+2013,chau,agsq,68.77438,170.54961,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.78691,170.5504,,,unknown,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.77563 E 170.55251
+2013,chau,sacr,68.78599,170.55077,20-Jun-13,20-Jun-13,2,2,e,
+2013,chau,agsq,68.78114,170.55141,,,unknown,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77563,170.55251,,,unknown,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.78691 E 170.5504
+2013,chau,glgu,68.78867,170.565,,,3,3,e,
+2013,chau,glgu,68.78022,170.56873,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,glgu,68.7852,170.5692,,,unknown,unknown,u,
+2013,chau,glgu,68.78053,170.56934,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.78036,170.57353,9-Jun-13,9-Jun-13,2,2,e,
+2013,chau,glgu,68.78247,170.57466,,,unknown,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2014,chau,agsq,68.77795,170.54265,25-Jun-14,25-Jun-14,unknown,unknown,u,unable to see inside den
+2014,chau,agsq,68.78192,170.54387,18-Jun-14,18-Jun-14,2,2,u,unable to see inside den.  Individuals appeard to be adults.  West 1/5 of ASDN surveyed
+2014,chau,glgu,68.78194,170.54828,12-Jun-14,12-Jun-14,unknown,unknown,u,Adult sitting on nest.  Unable to see contence of nest.  Nest on island surounded by deep water.
+2014,chau,glgu,68.78213,170.54851,25-Jun-14,25-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.77738,170.54878,14-Jun-14,14-Jun-14,6,6,u,unable to see inside den.
+2014,chau,vegu,68.7858,170.55478,25-Jun-14,25-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.78287,170.55822,12-Jun-14,12-Jun-14,1,1,u,"Unable to see inside den. Original GPS point lost, this GPS location is an estimate. "
+2014,chau,glgu,68.78022,170.56873,23-Jun-14,23-Jun-14,unknown,unknown,u,nest on island unable to see in side nest cup
+2012,chur,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2014,chur,paja,58.74163,-93.87878,15-Jun-14,15-Jun-14,2,2,u,"Observed adult sitting on nest, approached location and both adults defending nest with distraction displays, coordinates are approximate"
+2014,chur,paja,58.7432,-93.96733,4-Jun-14,4-Jun-14,2,2,2 e,Both adults defending territory
+2014,chur,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2014,coat,paja,62.86806,-82.49583,22-Jun-14,22-Jun-14,2,2,e,both adults acting like wimps defending territory
+2011,colv,rutu,70.42844,-150.66515,20-Jun-11,20-Jun-11,4,4,e,Adult defending territory
+2011,colv,rutu,70.42094,-150.66696,18-Jun-11,18-Jun-11,2,2,e,Both adults defending territory
+2011,colv,rutu,70.43555,-150.67552,14-Jun-11,14-Jun-11,3,3,e,Adult defending territory
+2011,colv,paja,70.42522,-150.67624,13-Jun-11,13-Jun-11,1,1,e,Both adults defending territory
+2011,colv,ltja,70.43938,-150.68398,7-Jun-11,7-Jun-11,2,2,e,Both adults defending territory
+2011,colv,rutu,70.43834,-150.68408,18-Jun-11,18-Jun-11,3,3,e,Adult defending territory
+2011,colv,rutu,70.43929,-150.6861,15-Jun-11,15-Jun-11,3,3,e,Adult defending territory
+2011,colv,rutu,70.43987,-150.6893,18-Jun-11,18-Jun-11,2,2,e,Adult defending territory
+2011,colv,glgu,70.43618,-150.70061,16-Jun-11,16-Jun-11,3,3,e,Both adults defending territory
+2011,colv,rutu,70.44189,-150.70624,18-Jun-11,18-Jun-11,4,4,e,Both adults defending territory
+2012,colv,rutu,70.42723,-150.66489,3-Jul-12,3-Jul-12,3,3,e,
+2012,colv,refo,70.42142,-150.66614,16-Jun-12,16-Jun-12,,,y,had 8 young around den later in year
+2012,colv,rutu,70.41962,-150.66731,11-Jun-12,11-Jun-12,4,4,e,
+2012,colv,paja,70.42522,-150.67624,13-Jun-12,13-Jun-12,2,2,e,
+2012,colv,rutu,70.43257,-150.67958,10-Jun-12,10-Jun-12,2,2,e,
+2012,colv,rutu,70.44202,-150.69092,18-Jun-12,18-Jun-12,4,4,e,
+2013,colv,rutu,70.42816,-150.65996,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43051,-150.66,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.42064,-150.66016,19-Jun-13,19-Jun-13,2,2,e,Both adults defending territory
+2013,colv,ltja,70.425,-150.66467,20-Jun-13,20-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.42792,-150.6647,20-Jun-13,20-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43369,-150.675,16-Jun-13,16-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43494,-150.67532,2-Jun-13,2-Jun-13,0,0,e,
+2013,colv,paja,70.42592,-150.67801,26-Jun-13,26-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.43761,-150.68243,18-Jun-13,18-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.44012,-150.68753,16-Jun-13,16-Jun-13,2,2,e,Both adults defending territory
+2013,colv,ltja,70.43972,-150.68816,12-Jun-13,12-Jun-13,2,2,e,Both adults defending territory
+2013,colv,rutu,70.44442,-150.69423,25-Jun-13,25-Jun-13,2,2,e,Both adults defending territory
+2014,colv,rutu,70.42586,-150.66476,10-Jun-14,10-Jun-14,4,4,e,
+2014,colv,refo,70.41237,-150.66621,3-Jun-14,3-Jun-14,3,3,y,1 adult present defending territory
+2014,colv,refo,70.41237,-150.66621,5-Jun-14,5-Jun-14,3,3,y,
+2014,colv,refo,70.41237,-150.66621,7-Jun-14,7-Jun-14,1,1,y,
+2014,colv,refo,70.41237,-150.66621,10-Jun-14,10-Jun-14,4,4,y,
+2014,colv,refo,70.41237,-150.66621,11-Jun-14,11-Jun-14,2,2,y,Both adults defending territory
+2014,colv,refo,70.41237,-150.66621,17-Jun-14,17-Jun-14,1,1,y,
+2014,colv,rutu,70.43016,-150.66713,10-Jun-14,10-Jun-14,4,4,e,
+2014,colv,rutu,70.42637,-150.66728,25-Jun-14,25-Jun-14,4,4,e,
+2014,colv,rutu,70.43123,-150.66792,11-Jun-14,11-Jun-14,4,4,e,
+2014,colv,cole,70.42586,-150.67499,7-Jun-14,7-Jun-14,1,1,adult,
+2014,colv,paja,70.42472,-150.67702,11-Jun-14,11-Jun-14,2,2,e,At least 1 chick observed hatched
+2014,colv,rutu,70.43823,-150.67867,13-Jun-14,13-Jun-14,3,3,e,
+2014,colv,rutu,70.43853,-150.68251,12-Jun-14,12-Jun-14,4,4,e,
+2014,colv,rutu,70.43929,-150.68611,21-Jun-14,21-Jun-14,4,4,e,
+2014,colv,rutu,70.43946,-150.6868,16-Jun-14,16-Jun-14,4,4,e,
+2014,colv,rutu,70.44868,-150.70607,29-Jun-14,29-Jun-14,4,4,e,
+2014,colv,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2012,eaba,herg,64.00547,-81.66993,19-Jun-12,19-Jun-12,2,2,e,"slightly territorial (1 hanging out around head, making alarm call)"
+2012,eaba,herg,63.9913,-81.72952,20-Jun-12,20-Jun-12,2,2,u,"1 adult defending strongly (v. close, persistant dive-bombing.  1 adult remained at nest, not sitting, called in 8 birds total flying overhead, unable to reach nest (too much aggression)"
+2012,eaba,herg,64.00547222,-81.66991667,19-Jun-12,19-Jun-12,2,2,e,1 egg
+2012,eaba,paja,63.99688889,-81.67402778,24-Jun-12,24-Jun-12,2,2,e,"2 eggs;pair of PAJA, broken wing display when we approached, when that didn't work they took to the air and dive-bombed us"
+2012,eaba,herg,63.99688889,-81.70175,24-Jun-12,24-Jun-12,3,3,e,"2 eggs; three hergs in total, nest was out in the middle of the water, they dive bombed when we approached"
+2012,eaba,herg,63.99205556,-81.71825,28-Jun-12,28-Jun-12,2,2,u,loon nest on same patch of land as HERG nest
+2012,eaba,herg,63.98211111,-81.72658333,12-Jun-12,12-Jun-12,12,12,e,1 egg; many adults defending nest
+2012,eaba,herg,63.98916667,-81.73230556,12-Jun-12,12-Jun-12,5,5,e,1 egg; many adults defending nest
+2012,eaba,paja,63.97872222,-81.71125,21-Jun-12,21-Jun-12,2,2,e,"2 eggs in nest, both adults very territorial: dive-bombing, calling, broken-wing display."
+2013,iglo,arfo,69.411991,-81.516148,20-Jul-13,20-Jul-13,2,2,,
+2014,iglo,ltja,69.38385,-81.60727,9-Jul-14,9-Jul-14,1,1,e,
+2014,iglo,ltja,69.38808,-81.55575,27-Jun-14,27-Jun-14,1,1,e,
+2014,iglo,rutu,69.40118,-81.54959,25-Jun-14,25-Jun-14,4,4,e,
+2014,iglo,rutu,69.40253,-81.53867,24-Jun-14,24-Jun-14,2,2,e,
+2014,iglo,herg/thgu,69.41021,-81.52865,29-Jun-14,29-Jun-14,2,2,e,
+2011,ikpi,agsq,70.54684,-154.66409,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,glgu,70.54747,-154.66608,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,glgu,70.54736,-154.66624,28-Jun-11,28-Jun-11,,,,incubating
+2011,ikpi,agsq,70.54521,-154.66698,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54388,-154.66975,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,seow,70.5501,-154.6722,30-Jun-11,30-Jun-11,5,5,e,
+2011,ikpi,agsq,70.54324,-154.67381,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.5427,-154.67409,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54241,-154.67596,16-Jun-11,16-Jun-11,,,,
+2011,ikpi,agsq,70.54193,-154.6805,14-Jul-11,14-Jul-11,,,,
+2011,ikpi,seow,70.53378,-154.68599,6-Jun-11,6-Jun-11,3,3,e,
+2011,ikpi,glgu,70.54389,-154.69827,13-Jun-11,13-Jun-11,,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,glgu,70.53801,-154.69958,11-Jun-11,11-Jun-11,,,,
+2011,ikpi,glgu,70.54469,-154.71005,13-Jun-11,13-Jun-11,,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,agsq,70.56364,-154.71143,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,agsq,70.56532,-154.71188,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,agsq,70.56535,-154.71197,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,agsq,70.57728,-154.7123,10-Jun-11,10-Jun-11,,,,
+2011,ikpi,agsq,70.5636,-154.71332,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,agsq,70.56361,-154.71332,14-Jun-11,14-Jun-11,,,,
+2011,ikpi,seow,70.536883,-154.71361,16-Jul-11,16-Jul-11,6,6,y,6 CHICKS IN NEST 1 CHICK 20M FROM NEST
+2011,ikpi,agsq,70.56477,-154.71465,27-Jun-11,27-Jun-11,,,,
+2011,ikpi,ltja,70.53659,-154.74094,12-Jun-11,12-Jun-11,,,e,
+2011,ikpi,agsq,70.53093,-154.75005,12-Jun-11,12-Jun-11,,,,
+2011,ikpi,glgu,70.53887,-154.75327,17-Jun-11,17-Jun-11,,,e,3 eggs
+2011,ikpi,seow,,,21-Jun-11,21-Jun-11,2,2,,"unknown nest contents, nest on plot 1 but no coordinates taken"
+2013,ikpi,agsq,70.55009,-154.65993,11-Jun-13,11-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54128,-154.68626,27-Jun-13,27-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54126,-154.68637,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55743,-154.68756,14-Jun-13,14-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55746,-154.68771,8-Jun-13,8-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54723,-154.6938,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54724,-154.69383,17-Jun-13,17-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,glgu,70.54456,-154.69501,24-Jun-13,24-Jun-13,unknown,unknown,u,contents not seen
+2013,ikpi,agsq,70.54971,-154.70293,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54377,-154.7037,13-Jun-13,13-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.548,-154.71068,12-Jun-13,12-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.56696,-154.71089,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,paja,70.55904,-154.71361,2-Jul-13,2-Jul-13,2,2,e,Both adults defending territory
+2013,ikpi,agsq,70.55781,-154.72096,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55762,-154.72266,7-Jun-13,7-Jun-13,unknown,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,poja,71.35783,-156.35123,4-Jun-12,4-Jun-12,2,2,e,Both adults defending territory
+2014,ikpi,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2012,lkri,ltja,72.8647,-106.0243,22-Jun-12,22-Jun-12,1,1,e,
+2012,lkri,paja,72.8261,-106.0605,7-Jul-12,7-Jul-12,2,2,e,
+2012,lkri,herg,72.837,-106.0747,13-Jul-12,13-Jul-12,3,3,e,
+2012,lkri,pefa,72.9321,-106.1042,11-Jul-12,11-Jul-12,4,4,e,
+2011,made,paja,69.34713829,-134.9102705,7-Jun-11,7-Jun-11,2,2,e,both adults in attack mode
+2011,made,paja,69.32381228,-135.3465797,10-Jun-11,10-Jun-11,1,1,e,
+2013,made,gyrf,69.37099,-134.88817,30-Jun-13,30-Jun-13,2,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,7-Jul-13,7-Jul-13,2,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,9-Jun-13,9-Jun-13,2,2,y,"Both adults defending territory, 4 chicks"
+2013,made,paja,69.3756,-134.95963,11-Jun-13,11-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,16-Jun-13,16-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,23-Jun-13,23-Jun-13,2,2,e,"Both adults defending territory, 2 eggs"
+2014,made,sacr,69.44953,-135.1624,25-Jun-14,25-Jun-14,2,2,e,
+2014,made,sacr,69.37762,-134.96043,10-Jun-14,10-Jun-14,1,1,e,
+2014,made,sacr,69.37032,-134.89946,7-Jun-14,7-Jun-14,2,2,e,
+2014,made,glgu,69.3529,-134.89166,23-Jun-14,23-Jun-14,3,3,e,
+2014,made,glgu,69.35506,-134.88759,23-Jun-14,23-Jun-14,3,3,e,
+2014,made,sacr,69.36963,-134.87822,9-Jun-14,9-Jun-14,1,1,e,
+2014,made,glgu,69.36726,-134.86641,16-Jun-14,16-Jun-14,3,3,e,
+2014,made,glgu,69.36774,-134.86429,16-Jun-14,16-Jun-14,2,2,e,
+2012,prba,ltja,70.21669,-148.51195,8-Jun-12,8-Jun-12,2,2,e,
+2012,prba,paja,70.35298,-148.61705,16-Jun-12,16-Jun-12,1,1,e,
+2012,prba,ltja,70.35362,-148.78622,20-Jun-12,20-Jun-12,2,2,e,
+2014,prba,poja,71.35783,-156.35123,4-Jun-14,4-Jun-14,2,2,e,Both adults defending territory
+2004,coat,herg,,,28-Jun-04,28-Jun-04,,,,
+2004,coat,herg,,,10-Jul-04,10-Jul-04,,,,
+2004,coat,paja,62.87864,-82.48539,4-Jul-04,4-Jul-04,,,e,
+2005,coat,herg,,,19-Jun-05,19-Jun-05,,,e,

--- a/tests/testdata/test-data_duplicate_rows.csv
+++ b/tests/testdata/test-data_duplicate_rows.csv
@@ -1,0 +1,237 @@
+Year,Site,Species,Nest_lat,Nest_lon,Date,Num_indiv,Nest_contents,Notes
+2011,barr,poja,71.35783,-156.35123,24-Jun-10,3,e,Both adults defending territory
+2012,barr,paja,71.26184,-156.5418,13-Jun-12,unknown,u,"location approximate; did not go to nest - adults chasing pefa, glgu away and sitting on ground in area"
+2012,barr,arfo,71.27126,-156.56042,17-Jun-12,4,y,800m w plot 3; no adult seen; pups going in and out of den (only 4 seen); told fox crew about it and they disposed of it quickly
+2012,barr,snow,71.29257,-156.64194,25-May-12,7,e,7e total; only 2 when found; on plot 2 in quadrat g13
+2012,barr,paja,71.28756,-156.6452,9-Jun-12,1,e,250m south of plot 2. female? was sitting on nest. male chased poja
+2013,barr,paja,71.26559,-156.54453,2-Jul-13,2,e,Nest seen by Rick Lanctot while searching for geo AMGP. Located about 300m west of D1 on plot 5
+2013,barr,paja,71.24587,-156.57292,25-Jun-13,2,e,"found 19 June, hatch 13 July"
+2013,barr,paja,71.30219,-156.63745,25-Jun-13,2,e,"NE of A13 Plot 1, a Brant nest in ca 100 m distance"
+2013,barr,paja,71.28745,-156.64046,16-Jul-13,,,"probably young, couldn't find nest but very broody behaviour "
+2014,barr,poja,71.28343,-156.58113,25-Jun-14,1,e,
+2014,barr,paja,71.24556,-156.57628,18-Jun-14,2,e,
+2014,barr,snow,,,26-May-14,9,e,"Near stake I10 on Plot 2.  7 chicks hatched, 3 survived to leave the nest.  Chicks last seen wandering around the north end of Plot 2 early August."
+2014,burn,herg,55.25621,-84.29432,12-Jun-14,3,e,
+2014,bylo,poja,71.35783,-156.35123,4-Jun-14,2,e,Both adults defending territory
+2011,cakr,glgu,67.11437,-163.47354,7-Jun-11,3,e,both adults defending territory
+2011,cakr,sacr,67.11426,-163.47861,7-Jun-11,2,e,"both adults defedended terriotry, nest depredated June 11th"
+2011,cakr,paja,67.1138,-163.49982,13-Jun-11,2,e,"both adults defended terriotry, one chick hatched June 22nd "
+2012,cakr,sacr,67.09837,-163.48256,23-Jun-12,1,e,"One egg has been depredated. Found shell at 3m from nest. Paja depredation? Shell pieces in nest, the remained egg have one little hole, but the membrane is not broken. The cranes were not there in the morning but came back in the afternoon around nest. "
+2012,cakr,sacr,67.09837,-163.48256,1-Jul-12,1,e,Still one egg and sacr around
+2012,cakr,paja,67.09783,-163.4838,23-Jun-12,2,e,
+2012,cakr,paja,67.09783,-163.4838,1-Jul-12,2,e,
+2012,cakr,paja,67.09783,-163.4838,6-Jul-12,2,e,
+2012,cakr,paja,67.11375,-163.50108,22-Jun-12,1,e,
+2012,cakr,paja,67.11375,-163.50108,11-Jun-12,1,e,1 egg depredated by common raven. Raven seen and they were 2 eggs at one point 
+2012,cakr,paja,67.11375,-163.50108,1-Jun-12,1,e,"parent on one egg, very cold outside. They are laying"
+2012,cakr,paja,67.11375,-163.50108,3-Jul-12,1,y,1 one seen at 40m from nest. Paja are very crazy!! Nothing in the nest
+2013,cakr,refo,67.1117,-163.48454,,unknown,u,"did not observe individuals entering den, but saw fresh tracks and know it was being used"
+2013,cakr,refo,67.11473,-163.46387,,1,u,only observed one individual entering den.
+2014,cakr,paja,67.11418,-163.47653,5-Jun-14,2,e,1 egg. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,10-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,15-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,20-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,25-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,29-May-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,4-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,10-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,15-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,20-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,21-Jun-14,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,22-Jun-14,2,"e,y",1 chick hatched. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,23-Jun-14,2,y,Both chicks hatched. Out of nest.
+2014,cakr,refo,67.11353,-163.55293,14-Jun-14,1,u,"Fox den off plot, near this point"
+2011,cari,snow,70.12315,-145.81639,9-Jun-11,2,e,7 eggs; Nest number 105SNOW. Nest failed 20 June.
+2011,cari,poja,70.10955,-145.82129,17-Jun-11,2,e,"2 eggs;Nest number 215POJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,paja,70.11593,-145.82785,17-Jun-11,2,e,"2 eggs;Nest number 729PAJA. 1E on 17 June, 2 on 22 June. Nest active 14 July."
+2011,cari,snow,70.13077,-145.83925,7-Jun-11,2,e,6 eggs; nest number 602SNOW. Nest failed 18 June.
+2011,cari,snow,70.09887,-145.8436,10-Jun-11,2,e,6 eggs; nest number 505SNOW. Nest failed 8 July.
+2011,cari,paja,70.12663,-145.84491,5-Jul-11,2,e,2 eggs;Nest number 176PAJA. Fate undetermined.
+2011,cari,arfo,70.11439,-145.84871,5-Jul-11,2,y,"~15 kits. Foxes frequently in study area, sometimes seen with dead adult shorebirds, likely cause of many depredated nests."
+2012,cari,paja,70.10468,-145.81955,19-Jun-12,2,e,nest failed 24 june
+2012,cari,paja,70.11613,-145.82742,11-Jun-12,2,e,nest failed 24 june
+2012,cari,paja,70.11613,-145.82742,11-Jun-12,2,e,nest failed 24 june
+2012,cari,paja,70.11613,-145.82742,11-Jun-12,2,e,nest failed 24 june
+2012,cari,glgu,70.10606,-145.82823,7-Jun-12,1,e,nest fate unknown
+2012,cari,rutu,70.11002,-145.84404,11-Jun-12,4,e,nest failed 16 june
+2012,cari,rutu,70.10709,-145.84717,14-Jun-12,2,e,nest failed 15 june
+2012,cari,rutu,70.1086,-145.84981,5-Jul-12,4,e,nest hatched to 4 chicks on 10-Jul
+2012,cari,glgu,70.12421,-145.85675,13-Jun-12,3,e,nest failed 20 jun
+2012,cari,glgu,70.1236,-145.85788,13-Jun-12,unknown,u,nest hatched at least 1 chick
+2013,cari,paja,70.11555,-145.832549,15-Jun-13,2,e,2 eggs;nest failed 26-Jun
+2013,cari,rutu,70.10954,-145.84889,19-Jun-13,2,e,4 eggs; nest failed 28-Jun
+2013,cari,glgu,70.09294,-145.884872,20-Jun-13,2,e,2 eggs;nest failed 25-Jun
+2013,cari,rutu,70.10681,-145.884937,25-Jun-13,2,e,4 eggs; nest hatched 28-Jun
+2013,cari,glgu,70.12439,-145.88544,14-Jun-13,2,e,3 eggs; hatched before 19-July
+2013,cari,glgu,70.12394,-145.885841,14-Jun-13,2,e,3 eggs
+2014,cari,snow,70.12363,-145.79929,15-Jun-14,6,e,2c on 7 jul
+2014,cari,poja,70.11937,-145.8163,16-Jun-14,1,e,fail 28 jun
+2014,cari,paja,70.11582,-145.82393,15-Jun-14,2,e,hatch 10 jul
+2014,cari,seow,70.11781,-145.83875,19-Jun-14,7,e,fail 19 jun
+2014,cari,rutu,70.10986,-145.84076,12-Jun-14,4,e,failed 22 jun
+2014,cari,rutu,70.10974,-145.84128,24-Jun-14,2,e,hatch 14 jul
+2014,cari,arfo,70.11565,-145.84196,7-Jun-14,7,y,7 kits counted
+2014,cari,rutu,70.10999,-145.84482,1-Jul-14,1,e,hatch 2 jul
+2014,cari,glgu,70.12481,-145.85648,9-Jun-14,,,failed prior to 25 jun
+2012,chau,poja,71.35783,-156.35123,4-Jun-12,2,e,Both adults defending territory
+2013,chau,agsq,68.77785,170.54257,,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77591,170.5463,,unknown,u,Unknown contents in ground squirrel den
+2013,chau,glgu,68.78194,170.54828,,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.77802,170.54875,7-Jun-13,2,e,
+2013,chau,sacr,68.77802,170.54875,25-Jun-13,1,e,
+2013,chau,agsq,68.77438,170.54961,,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.78691,170.5504,,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.77563 E 170.55251
+2013,chau,sacr,68.78599,170.55077,20-Jun-13,2,e,
+2013,chau,agsq,68.78114,170.55141,,unknown,u,Unknown contents in ground squirrel den
+2013,chau,agsq,68.77563,170.55251,,unknown,u,Unknown contents in ground squirrel den. Abundant squirrel activity between this point and point at N 68.78691 E 170.5504
+2013,chau,glgu,68.78867,170.565,,3,e,
+2013,chau,glgu,68.78022,170.56873,,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,glgu,68.7852,170.5692,,unknown,u,
+2013,chau,glgu,68.78053,170.56934,,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2013,chau,sacr,68.78036,170.57353,9-Jun-13,2,e,
+2013,chau,glgu,68.78247,170.57466,,unknown,u,"Nest is on a small island in a big lake, waypoint is approximate"
+2014,chau,agsq,68.77795,170.54265,25-Jun-14,unknown,u,unable to see inside den
+2014,chau,agsq,68.78192,170.54387,18-Jun-14,2,u,unable to see inside den.  Individuals appeard to be adults.  West 1/5 of ASDN surveyed
+2014,chau,glgu,68.78194,170.54828,12-Jun-14,unknown,u,Adult sitting on nest.  Unable to see contence of nest.  Nest on island surounded by deep water.
+2014,chau,glgu,68.78213,170.54851,25-Jun-14,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.77738,170.54878,14-Jun-14,6,u,unable to see inside den.
+2014,chau,vegu,68.7858,170.55478,25-Jun-14,unknown,u,nest on island unable to see in side nest cup
+2014,chau,agsq,68.78287,170.55822,12-Jun-14,1,u,"Unable to see inside den. Original GPS point lost, this GPS location is an estimate. "
+2014,chau,glgu,68.78022,170.56873,23-Jun-14,unknown,u,nest on island unable to see in side nest cup
+2012,chur,poja,71.35783,-156.35123,4-Jun-12,2,e,Both adults defending territory
+2014,chur,paja,58.74163,-93.87878,15-Jun-14,2,u,"Observed adult sitting on nest, approached location and both adults defending nest with distraction displays, coordinates are approximate"
+2014,chur,paja,58.7432,-93.96733,4-Jun-14,2,2 e,Both adults defending territory
+2014,chur,poja,71.35783,-156.35123,4-Jun-14,2,e,Both adults defending territory
+2014,coat,paja,62.86806,-82.49583,22-Jun-14,2,e,both adults acting like wimps defending territory
+2011,colv,rutu,70.42844,-150.66515,20-Jun-11,4,e,Adult defending territory
+2011,colv,rutu,70.42094,-150.66696,18-Jun-11,2,e,Both adults defending territory
+2011,colv,rutu,70.43555,-150.67552,14-Jun-11,3,e,Adult defending territory
+2011,colv,paja,70.42522,-150.67624,13-Jun-11,1,e,Both adults defending territory
+2011,colv,ltja,70.43938,-150.68398,7-Jun-11,2,e,Both adults defending territory
+2011,colv,rutu,70.43834,-150.68408,18-Jun-11,3,e,Adult defending territory
+2011,colv,rutu,70.43929,-150.6861,15-Jun-11,3,e,Adult defending territory
+2011,colv,rutu,70.43987,-150.6893,18-Jun-11,2,e,Adult defending territory
+2011,colv,glgu,70.43618,-150.70061,16-Jun-11,3,e,Both adults defending territory
+2011,colv,rutu,70.44189,-150.70624,18-Jun-11,4,e,Both adults defending territory
+2012,colv,rutu,70.42723,-150.66489,3-Jul-12,3,e,
+2012,colv,refo,70.42142,-150.66614,16-Jun-12,,y,had 8 young around den later in year
+2012,colv,rutu,70.41962,-150.66731,11-Jun-12,4,e,
+2012,colv,paja,70.42522,-150.67624,13-Jun-12,2,e,
+2012,colv,rutu,70.43257,-150.67958,10-Jun-12,2,e,
+2012,colv,rutu,70.44202,-150.69092,18-Jun-12,4,e,
+2013,colv,rutu,70.42816,-150.65996,19-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.43051,-150.66,19-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.42064,-150.66016,19-Jun-13,2,e,Both adults defending territory
+2013,colv,ltja,70.425,-150.66467,20-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.42792,-150.6647,20-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.43369,-150.675,16-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.43494,-150.67532,2-Jun-13,0,e,
+2013,colv,paja,70.42592,-150.67801,26-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.43761,-150.68243,18-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.44012,-150.68753,16-Jun-13,2,e,Both adults defending territory
+2013,colv,ltja,70.43972,-150.68816,12-Jun-13,2,e,Both adults defending territory
+2013,colv,rutu,70.44442,-150.69423,25-Jun-13,2,e,Both adults defending territory
+2014,colv,rutu,70.42586,-150.66476,10-Jun-14,4,e,
+2014,colv,refo,70.41237,-150.66621,3-Jun-14,3,y,1 adult present defending territory
+2014,colv,refo,70.41237,-150.66621,5-Jun-14,3,y,
+2014,colv,refo,70.41237,-150.66621,7-Jun-14,1,y,
+2014,colv,refo,70.41237,-150.66621,10-Jun-14,4,y,
+2014,colv,refo,70.41237,-150.66621,11-Jun-14,2,y,Both adults defending territory
+2014,colv,refo,70.41237,-150.66621,17-Jun-14,1,y,
+2014,colv,rutu,70.43016,-150.66713,10-Jun-14,4,e,
+2014,colv,rutu,70.42637,-150.66728,25-Jun-14,4,e,
+2014,colv,rutu,70.43123,-150.66792,11-Jun-14,4,e,
+2014,colv,cole,70.42586,-150.67499,7-Jun-14,1,adult,
+2014,colv,paja,70.42472,-150.67702,11-Jun-14,2,e,At least 1 chick observed hatched
+2014,colv,rutu,70.43823,-150.67867,13-Jun-14,3,e,
+2014,colv,rutu,70.43853,-150.68251,12-Jun-14,4,e,
+2014,colv,rutu,70.43929,-150.68611,21-Jun-14,4,e,
+2014,colv,rutu,70.43946,-150.6868,16-Jun-14,4,e,
+2014,colv,rutu,70.44868,-150.70607,29-Jun-14,4,e,
+2014,colv,poja,71.35783,-156.35123,4-Jun-14,2,e,Both adults defending territory
+2012,eaba,herg,64.00547,-81.66993,19-Jun-12,2,e,"slightly territorial (1 hanging out around head, making alarm call)"
+2012,eaba,herg,63.9913,-81.72952,20-Jun-12,2,u,"1 adult defending strongly (v. close, persistant dive-bombing.  1 adult remained at nest, not sitting, called in 8 birds total flying overhead, unable to reach nest (too much aggression)"
+2012,eaba,herg,64.00547222,-81.66991667,19-Jun-12,2,e,1 egg
+2012,eaba,paja,63.99688889,-81.67402778,24-Jun-12,2,e,"2 eggs;pair of PAJA, broken wing display when we approached, when that didn't work they took to the air and dive-bombed us"
+2012,eaba,herg,63.99688889,-81.70175,24-Jun-12,3,e,"2 eggs; three hergs in total, nest was out in the middle of the water, they dive bombed when we approached"
+2012,eaba,herg,63.99205556,-81.71825,28-Jun-12,2,u,loon nest on same patch of land as HERG nest
+2012,eaba,herg,63.98211111,-81.72658333,12-Jun-12,12,e,1 egg; many adults defending nest
+2012,eaba,herg,63.98916667,-81.73230556,12-Jun-12,5,e,1 egg; many adults defending nest
+2012,eaba,paja,63.97872222,-81.71125,21-Jun-12,2,e,"2 eggs in nest, both adults very territorial: dive-bombing, calling, broken-wing display."
+2013,iglo,arfo,69.411991,-81.516148,20-Jul-13,2,,
+2014,iglo,ltja,69.38385,-81.60727,9-Jul-14,1,e,
+2014,iglo,ltja,69.38808,-81.55575,27-Jun-14,1,e,
+2014,iglo,rutu,69.40118,-81.54959,25-Jun-14,4,e,
+2014,iglo,rutu,69.40253,-81.53867,24-Jun-14,2,e,
+2014,iglo,herg/thgu,69.41021,-81.52865,29-Jun-14,2,e,
+2011,ikpi,agsq,70.54684,-154.66409,16-Jun-11,,,
+2011,ikpi,glgu,70.54747,-154.66608,16-Jun-11,,,
+2011,ikpi,glgu,70.54736,-154.66624,28-Jun-11,,,incubating
+2011,ikpi,agsq,70.54521,-154.66698,16-Jun-11,,,
+2011,ikpi,agsq,70.54388,-154.66975,16-Jun-11,,,
+2011,ikpi,seow,70.5501,-154.6722,30-Jun-11,5,e,
+2011,ikpi,agsq,70.54324,-154.67381,16-Jun-11,,,
+2011,ikpi,agsq,70.5427,-154.67409,16-Jun-11,,,
+2011,ikpi,agsq,70.54241,-154.67596,16-Jun-11,,,
+2011,ikpi,agsq,70.54193,-154.6805,14-Jul-11,,,
+2011,ikpi,seow,70.53378,-154.68599,6-Jun-11,3,e,
+2011,ikpi,glgu,70.54389,-154.69827,13-Jun-11,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,glgu,70.53801,-154.69958,11-Jun-11,,,
+2011,ikpi,glgu,70.54469,-154.71005,13-Jun-11,,,"Nest is on an island, unknown contents. Lake is deep location estimated"
+2011,ikpi,agsq,70.56364,-154.71143,14-Jun-11,,,
+2011,ikpi,agsq,70.56532,-154.71188,14-Jun-11,,,
+2011,ikpi,agsq,70.56535,-154.71197,27-Jun-11,,,
+2011,ikpi,agsq,70.57728,-154.7123,10-Jun-11,,,
+2011,ikpi,agsq,70.5636,-154.71332,27-Jun-11,,,
+2011,ikpi,agsq,70.56361,-154.71332,14-Jun-11,,,
+2011,ikpi,seow,70.536883,-154.71361,16-Jul-11,6,y,6 CHICKS IN NEST 1 CHICK 20M FROM NEST
+2011,ikpi,agsq,70.56477,-154.71465,27-Jun-11,,,
+2011,ikpi,ltja,70.53659,-154.74094,12-Jun-11,,e,
+2011,ikpi,agsq,70.53093,-154.75005,12-Jun-11,,,
+2011,ikpi,glgu,70.53887,-154.75327,17-Jun-11,,e,3 eggs
+2011,ikpi,seow,,,21-Jun-11,2,,"unknown nest contents, nest on plot 1 but no coordinates taken"
+2013,ikpi,agsq,70.55009,-154.65993,11-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54128,-154.68626,27-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54126,-154.68637,12-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55743,-154.68756,14-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55746,-154.68771,8-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54723,-154.6938,12-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54724,-154.69383,17-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,glgu,70.54456,-154.69501,24-Jun-13,unknown,u,contents not seen
+2013,ikpi,agsq,70.54971,-154.70293,12-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.54377,-154.7037,13-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.548,-154.71068,12-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.56696,-154.71089,7-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,paja,70.55904,-154.71361,2-Jul-13,2,e,Both adults defending territory
+2013,ikpi,agsq,70.55781,-154.72096,7-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,agsq,70.55762,-154.72266,7-Jun-13,unknown,u,"ground squirrel den, contents not seen"
+2013,ikpi,poja,71.35783,-156.35123,4-Jun-12,2,e,Both adults defending territory
+2014,ikpi,poja,71.35783,-156.35123,4-Jun-14,2,e,Both adults defending territory
+2012,lkri,ltja,72.8647,-106.0243,22-Jun-12,1,e,
+2012,lkri,paja,72.8261,-106.0605,7-Jul-12,2,e,
+2012,lkri,herg,72.837,-106.0747,13-Jul-12,3,e,
+2012,lkri,pefa,72.9321,-106.1042,11-Jul-12,4,e,
+2011,made,paja,69.34713829,-134.9102705,7-Jun-11,2,e,both adults in attack mode
+2011,made,paja,69.32381228,-135.3465797,10-Jun-11,1,e,
+2013,made,gyrf,69.37099,-134.88817,30-Jun-13,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,7-Jul-13,2,y,2 chicks
+2013,made,gyrf,69.37099,-134.88817,9-Jun-13,2,y,"Both adults defending territory, 4 chicks"
+2013,made,paja,69.3756,-134.95963,11-Jun-13,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,16-Jun-13,2,e,"Both adults defending territory, 2 eggs"
+2013,made,paja,69.3756,-134.95963,23-Jun-13,2,e,"Both adults defending territory, 2 eggs"
+2014,made,sacr,69.44953,-135.1624,25-Jun-14,2,e,
+2014,made,sacr,69.37762,-134.96043,10-Jun-14,1,e,
+2014,made,sacr,69.37032,-134.89946,7-Jun-14,2,e,
+2014,made,glgu,69.3529,-134.89166,23-Jun-14,3,e,
+2014,made,glgu,69.35506,-134.88759,23-Jun-14,3,e,
+2014,made,sacr,69.36963,-134.87822,9-Jun-14,1,e,
+2014,made,glgu,69.36726,-134.86641,16-Jun-14,3,e,
+2014,made,glgu,69.36774,-134.86429,16-Jun-14,2,e,
+2012,prba,ltja,70.21669,-148.51195,8-Jun-12,2,e,
+2012,prba,paja,70.35298,-148.61705,16-Jun-12,1,e,
+2012,prba,ltja,70.35362,-148.78622,20-Jun-12,2,e,
+2014,prba,poja,71.35783,-156.35123,4-Jun-14,2,e,Both adults defending territory
+2004,coat,herg,,,28-Jun-04,,,
+2004,coat,herg,,,10-Jul-04,,,
+2004,coat,paja,62.87864,-82.48539,4-Jul-04,,e,
+2005,coat,herg,,,19-Jun-05,,e,

--- a/tests/testdata/test-data_illegalcharacter.csv
+++ b/tests/testdata/test-data_illegalcharacter.csv
@@ -1,7 +1,4 @@
-This row must be skipped
-# And this one as well
-And so does this one
-Year,Site,Species,Nest_lat,Nest_lon,Date,Num_indiv,Nest_contents,Notes
+_þïþÿSite,Species,Nest_lat,Nest_lon,Date,Num_indiv,Nest_contents,Notes
 2011,barr,poja,71.35783,-156.35123,24-Jun-10,3,e,Both adults defending territory
 2012,barr,paja,71.26184,-156.5418,13-Jun-12,unknown,u,"location approximate; did not go to nest - adults chasing pefa, glgu away and sitting on ground in area"
 2012,barr,arfo,71.27126,-156.56042,17-Jun-12,4,y,800m w plot 3; no adult seen; pups going in and out of den (only 4 seen); told fox crew about it and they disposed of it quickly
@@ -31,11 +28,11 @@ Year,Site,Species,Nest_lat,Nest_lon,Date,Num_indiv,Nest_contents,Notes
 2013,cakr,refo,67.1117,-163.48454,,unknown,u,"did not observe individuals entering den, but saw fresh tracks and know it was being used"
 2013,cakr,refo,67.11473,-163.46387,,1,u,only observed one individual entering den.
 2014,cakr,paja,67.11418,-163.47653,5-Jun-14,2,e,1 egg. Both adults defending territory
-2014,cakr,paja,67.11418,-163.47653,10-Jun-14,2,e,2 eggs. Both adults defending territoryðŸ˜ 
-2014,cakr,paja,67.11418,-163.47653,15-Jun-14,2,e,2 eggs. Both adults defending territoryðŸ˜ 
-2014,cakr,paja,67.11418,-163.47653,20-Jun-14,2,e,2 eggs. Both adults defending territoryðŸ˜ 
-2014,cakr,paja,67.11418,-163.47653,25-Jun-14,2,e,2 eggs. Both adults defending territoryðŸ˜ 
-2014,cakr,paja,67.11375,-163.49986,29-May-14,2,e,2 eggs. Both adults defending territoryðŸ˜ 
+2014,cakr,paja,67.11418,-163.47653,10-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,15-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,20-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11418,-163.47653,25-Jun-14,2,e,2 eggs. Both adults defending territory
+2014,cakr,paja,67.11375,-163.49986,29-May-14,2,e,2 eggs. Both adults defending territory
 2014,cakr,paja,67.11375,-163.49986,4-Jun-14,2,e,2 eggs. Both adults defending territory
 2014,cakr,paja,67.11375,-163.49986,10-Jun-14,2,e,2 eggs. Both adults defending territory
 2014,cakr,paja,67.11375,-163.49986,15-Jun-14,2,e,2 eggs. Both adults defending territory


### PR DESCRIPTION
**Summary of Changes:**
- Added new `suites` module to run entire quality suites
- Added new utility functions to the `metadata` module to assist with various data checks, along with additional pytests and new test data documents
- `metadig-py` now ships with a default hashstore which is used by the `metadigclient`. You can use the `metadigclient` to import data to hashstore so that you can run a data suite locally
- Cleaned up pytests to improve ease of understanding
- Updated `README.md` with documentation on how to use the default hashstore.